### PR TITLE
Improved interactions workflow. Better error logging. Fix bug in link.

### DIFF
--- a/compiler/compiler_internal.go
+++ b/compiler/compiler_internal.go
@@ -176,7 +176,7 @@ func mapCondition(c Condition, name string, postedAt types.ISO8601) (types.Condi
 
 	operands, err := mapOperands(strOperands)
 	if err != nil {
-		return types.Condition{}, err
+		return types.Condition{}, fmt.Errorf("while parsing condition's operands: %w", err)
 	}
 
 	if operator != ">" && operator != "<" && operator != ">=" && operator != "<=" && operator != "BETWEEN" {
@@ -189,22 +189,22 @@ func mapCondition(c Condition, name string, postedAt types.ISO8601) (types.Condi
 
 	stateValue, err := types.ConditionStateValueFromString(c.State.Value)
 	if err != nil {
-		return types.Condition{}, err
+		return types.Condition{}, fmt.Errorf("while parsing condition's stateValue: %w", err)
 	}
 
 	stateStatus, err := types.ConditionStatusFromString(c.State.Status)
 	if err != nil {
-		return types.Condition{}, err
+		return types.Condition{}, fmt.Errorf("while parsing condition's stateStatus: %w", err)
 	}
 
 	fromTs, err := mapFromTs(c, postedAt)
 	if err != nil {
-		return types.Condition{}, err
+		return types.Condition{}, fmt.Errorf("while parsing condition's fromTs: %w", err)
 	}
 
 	toTs, err := mapToTs(c, fromTs)
 	if err != nil {
-		return types.Condition{}, err
+		return types.Condition{}, fmt.Errorf("while parsing condition's toTs: %w", err)
 	}
 
 	return types.Condition{

--- a/market/coinbase/coinbase.go
+++ b/market/coinbase/coinbase.go
@@ -58,7 +58,7 @@ func (e *Coinbase) RequestCandlesticks(operand types.Operand, startTimeTs int, i
 //
 // Some exchanges may return results for unfinished candles (e.g. the current minute) and some may not, so callers
 // should not request unfinished candles. This patience should be taken into account in addition to unfinished candles.
-func (e *Coinbase) GetPatience() time.Duration { return 1 * time.Minute }
+func (e *Coinbase) GetPatience() time.Duration { return 2 * time.Minute }
 
 // SetDebug sets exchange-wide debug logging. It's useful to know how many times requests are being sent to exchanges.
 func (e *Coinbase) SetDebug(debug bool) {

--- a/metadatafetcher/twitter/fetcher.go
+++ b/metadatafetcher/twitter/fetcher.go
@@ -30,22 +30,22 @@ func (f MetadataFetcher) Fetch(u *url.URL) (types.PostMetadata, error) {
 
 	tweet, err := NewTwitter(f.apiURL).getTweetByID(path[3])
 	if err != nil {
-		return types.PostMetadata{}, err
+		return types.PostMetadata{}, fmt.Errorf("while getting tweet by ID (%v): %w", path[3], err)
 	}
 
 	userURL, err := url.Parse(fmt.Sprintf("https://twitter.com/%v", tweet.UserHandle))
 	if err != nil {
-		return types.PostMetadata{}, fmt.Errorf("error parsing user's URL: %v", err)
+		return types.PostMetadata{}, fmt.Errorf("error parsing user's URL: %w", err)
 	}
 
 	userProfileImgURL, err := url.Parse(tweet.ProfileImgURL)
 	if err != nil {
-		return types.PostMetadata{}, fmt.Errorf("error parsing user's profile image URL: %v", err)
+		return types.PostMetadata{}, fmt.Errorf("error parsing user's profile image URL: %w", err)
 	}
 
 	userProfileMediumImgURL, err := url.Parse(strings.Replace(tweet.ProfileImgURL, "_normal.", "_400x400.", -1))
 	if err != nil {
-		return types.PostMetadata{}, fmt.Errorf("error parsing user's profile medium image URL: %v", err)
+		return types.PostMetadata{}, fmt.Errorf("error parsing user's profile medium image URL: %w", err)
 	}
 
 	return types.PostMetadata{

--- a/statestorage/migrations/1656760569_alter_prediction_interactions_status.down.sql
+++ b/statestorage/migrations/1656760569_alter_prediction_interactions_status.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "prediction_interactions"
+  DROP COLUMN "status",
+  DROP COLUMN "error";

--- a/statestorage/migrations/1656760569_alter_prediction_interactions_status.up.sql
+++ b/statestorage/migrations/1656760569_alter_prediction_interactions_status.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "prediction_interactions"
+  ADD COLUMN "status" text NOT NULL DEFAULT 'POSTED',
+  ADD COLUMN "error" text;

--- a/statestorage/state_storage.go
+++ b/statestorage/state_storage.go
@@ -16,13 +16,18 @@ type StateStorage interface {
 	UpsertPredictions([]*types.Prediction) ([]*types.Prediction, error)
 	UpsertAccounts([]*types.Account) ([]*types.Account, error)
 	LogPredictionStateValueChange(types.PredictionStateValueChange) error
-	PredictionInteractionExists(predictionUUID, postURL, actionType string) (bool, error)
-	InsertPredictionInteraction(predictionUUID, postURL, actionType, interactionPostURL string) error
+
+	NonPendingPredictionInteractionExists(types.PredictionInteraction) (bool, error)
+	InsertPredictionInteraction(types.PredictionInteraction) error
+	GetPendingPredictionInteractions() ([]types.PredictionInteraction, error)
+	UpdatePredictionInteractionStatus(types.PredictionInteraction) error
+
 	PausePrediction(uuid string) error
 	UnpausePrediction(uuid string) error
 	HidePrediction(uuid string) error
 	UnhidePrediction(uuid string) error
 	DeletePrediction(uuid string) error
 	UndeletePrediction(uuid string) error
+
 	DB() *sql.DB
 }

--- a/types/types.go
+++ b/types/types.go
@@ -695,3 +695,13 @@ func (v PredictionType) String() string {
 		return "PREDICTION_TYPE_UNSUPPORTED"
 	}
 }
+
+// PredictionInteraction is a social media post posted by this engine upon an event of a prediction.
+type PredictionInteraction struct {
+	PostURL            string
+	ActionType         string
+	InteractionPostURL string
+	PredictionUUID     string
+	Status             string // PENDING, POSTED, ERROR
+	Error              string
+}


### PR DESCRIPTION
- Interactions (i.e. posting on twitter when predictions are created and become final) are now queued as rows set to PENDING in the `prediction_interactions` table.
- At the end of a Daemon run, the first 3 PENDING interactions will be actioned. The rest will have to wait until the next run, solving the issue of too many predictions being actioned at once at periods like end of year and the like.
- When there is an error with actioning an interaction, the row's status will be ERROR and the error column will have a description of the issue. This allows for an administrator to manually fix the problem and set the row to PENDING again.

This PR also adds a lot of useful compilation logging (seen in the BackOffice when adding predictions). It also fixes a bug whereby links to the website are incorrectly constructed.