### PR TITLE
Rename types package to core.

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -10,13 +10,13 @@ import (
 	"github.com/google/uuid"
 	"github.com/marianogappa/crypto-candles/candles/common"
 	"github.com/marianogappa/predictions/compiler"
+	"github.com/marianogappa/predictions/core"
 	"github.com/marianogappa/predictions/daemon"
 	"github.com/marianogappa/predictions/imagebuilder"
 	"github.com/marianogappa/predictions/metadatafetcher"
 	fetcherTypes "github.com/marianogappa/predictions/metadatafetcher/types"
 	"github.com/marianogappa/predictions/serializer"
 	"github.com/marianogappa/predictions/statestorage"
-	"github.com/marianogappa/predictions/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -289,13 +289,13 @@ func TestAPI(t *testing.T) {
 			name: "getPagesPrediction with url",
 			test: func(t *testing.T, a *API, ctx testContext) {
 				// Create sample predictions with different attributes
-				samplePreds := []types.Prediction{}
-				sampleAccounts := []*types.Account{}
+				samplePreds := []core.Prediction{}
+				sampleAccounts := []*core.Account{}
 				for i := 0; i < 10; i++ {
 					samplePred, sampleAccount := compile(t, sampleRawPrediction)
 					samplePred.UUID = uuid.NewString()
 					samplePred.PostURL = fmt.Sprintf("https://twitter.com/differentUser/status/%v", i)
-					samplePred.PostedAt = types.ISO8601(fmt.Sprintf("2020-06-26T00:00:0%vZ", i))
+					samplePred.PostedAt = core.ISO8601(fmt.Sprintf("2020-06-26T00:00:0%vZ", i))
 					samplePred.PostAuthor = fmt.Sprintf("User%v", i)
 					samplePred.PostAuthorURL = fmt.Sprintf("https://twitter.com/user%v", i)
 
@@ -405,15 +405,15 @@ func addTestFetcher(mf *metadatafetcher.MetadataFetcher) {
 	postAuthorURL, _ := url.Parse("https://twitter.com/CryptoCapo_")
 	mf.Fetchers = []metadatafetcher.SpecificFetcher{
 		testFetcher{isCorrectFetcher: true, postMetadata: fetcherTypes.PostMetadata{
-			Author:        types.Account{Handle: "test author", URL: postAuthorURL},
+			Author:        core.Account{Handle: "test author", URL: postAuthorURL},
 			PostCreatedAt: tpToISO("2022-01-02 00:00:00"),
 		}, err: nil},
 	}
 }
 
-func tpToISO(s string) types.ISO8601 {
+func tpToISO(s string) core.ISO8601 {
 	t, _ := time.Parse("2006-01-02 15:04:05", s)
-	return types.ISO8601(t.Format(time.RFC3339))
+	return core.ISO8601(t.Format(time.RFC3339))
 }
 
 type testContext struct {
@@ -448,7 +448,7 @@ var (
 	}`)
 )
 
-func compile(t *testing.T, rawPrediction []byte) (types.Prediction, *types.Account) {
+func compile(t *testing.T, rawPrediction []byte) (core.Prediction, *core.Account) {
 	mf := metadatafetcher.NewMetadataFetcher()
 	addTestFetcher(mf)
 	compiledPrediction, account, err := compiler.NewPredictionCompiler(mf, time.Now).Compile(sampleRawPrediction)
@@ -456,7 +456,7 @@ func compile(t *testing.T, rawPrediction []byte) (types.Prediction, *types.Accou
 	return compiledPrediction, account
 }
 
-func serialize(t *testing.T, prediction types.Prediction) string {
+func serialize(t *testing.T, prediction core.Prediction) string {
 	rawPrediction, err := serializer.NewPredictionSerializer(nil).Serialize(&prediction)
 	require.Nil(t, err)
 	return string(rawPrediction)

--- a/api/errors.go
+++ b/api/errors.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 
 	"github.com/marianogappa/crypto-candles/candles/common"
-	"github.com/marianogappa/predictions/types"
+	"github.com/marianogappa/predictions/core"
 )
 
 // ErrorContent struct contains necessary data to return an error compliant with the API spec.
@@ -47,31 +47,31 @@ var (
 	ErrPredictionNotFound = errors.New("prediction not found")
 
 	errToResponse = map[error]ErrorContent{
-		types.ErrUnknownOperandType:                 {StatusCode: 400, ErrorCode: "ErrUnknownOperandType", Message: "unknown value for operandType"},
-		types.ErrUnknownBoolOperator:                {StatusCode: 400, ErrorCode: "ErrUnknownBoolOperator", Message: "unknown value for BoolOperator"},
-		types.ErrUnknownConditionStatus:             {StatusCode: 400, ErrorCode: "ErrUnknownConditionStatus", Message: "invalid state: unknown value for ConditionStatus"},
-		types.ErrUnknownPredictionStateValue:        {StatusCode: 400, ErrorCode: "ErrUnknownPredictionStateValue", Message: "invalid state: unknown value for PredictionStateValue"},
-		types.ErrInvalidOperand:                     {StatusCode: 400, ErrorCode: "ErrInvalidOperand", Message: "invalid operand"},
-		types.ErrEmptyQuoteAsset:                    {StatusCode: 400, ErrorCode: "ErrEmptyQuoteAsset", Message: "quote asset cannot be empty"},
-		types.ErrNonEmptyQuoteAssetOnNonCoin:        {StatusCode: 400, ErrorCode: "ErrNonEmptyQuoteAssetOnNonCoin", Message: "quote asset must be empty for non-coin operand types"},
-		types.ErrEqualBaseQuoteAssets:               {StatusCode: 400, ErrorCode: "ErrEqualBaseQuoteAssets", Message: "base asset cannot be equal to quote asset"},
-		types.ErrInvalidDuration:                    {StatusCode: 400, ErrorCode: "ErrInvalidDuration", Message: "invalid duration"},
-		types.ErrInvalidFromISO8601:                 {StatusCode: 400, ErrorCode: "ErrInvalidFromISO8601", Message: "invalid FromISO8601"},
-		types.ErrInvalidToISO8601:                   {StatusCode: 400, ErrorCode: "ErrInvalidToISO8601", Message: "invalid ToISO8601"},
-		types.ErrOneOfToISO8601ToDurationRequired:   {StatusCode: 400, ErrorCode: "ErrOneOfToISO8601ToDurationRequired", Message: "one of ToISO8601 or ToDuration is required"},
-		types.ErrInvalidConditionSyntax:             {StatusCode: 400, ErrorCode: "ErrInvalidConditionSyntax", Message: "invalid condition syntax"},
-		types.ErrUnknownConditionOperator:           {StatusCode: 400, ErrorCode: "ErrUnknownConditionOperator", Message: "unknown condition operator: supported are [>|<|>=|<=|BETWEEN...AND]"},
-		types.ErrErrorMarginRatioAbove30:            {StatusCode: 400, ErrorCode: "ErrErrorMarginRatioAbove30", Message: "error margin ratio above 30%% is not allowed"},
-		types.ErrInvalidJSON:                        {StatusCode: 400, ErrorCode: "ErrInvalidJSON", Message: "invalid JSON"},
-		types.ErrEmptyReporter:                      {StatusCode: 400, ErrorCode: "ErrEmptyReporter", Message: "reporter cannot be empty"},
-		types.ErrEmptyPostURL:                       {StatusCode: 400, ErrorCode: "ErrEmptyPostURL", Message: "postUrl cannot be empty"},
-		types.ErrEmptyPostAuthor:                    {StatusCode: 400, ErrorCode: "ErrEmptyPostAuthor", Message: "postAuthor cannot be empty"},
-		types.ErrEmptyPostedAt:                      {StatusCode: 400, ErrorCode: "ErrEmptyPostedAt", Message: "postedAt cannot be empty"},
-		types.ErrInvalidPostedAt:                    {StatusCode: 400, ErrorCode: "ErrInvalidPostedAt", Message: "postedAt must be a valid ISO8601 timestamp"},
-		types.ErrEmptyPredict:                       {StatusCode: 400, ErrorCode: "ErrEmptyPredict", Message: "main predict clause cannot be empty"},
-		types.ErrMissingRequiredPrePredictPredictIf: {StatusCode: 400, ErrorCode: "ErrMissingRequiredPrePredictPredictIf", Message: "pre-predict clause must have predictIf if it has either wrongIf or annuledIf. Otherwise, add them directly on predict clause"},
-		types.ErrBoolExprSyntaxError:                {StatusCode: 400, ErrorCode: "ErrBoolExprSyntaxError", Message: "syntax error in bool expression"},
-		types.ErrPredictionFinishedAtStartTime:      {StatusCode: 400, ErrorCode: "ErrPredictionFinishedAtStartTime", Message: "prediction is finished at start time"},
+		core.ErrUnknownOperandType:                 {StatusCode: 400, ErrorCode: "ErrUnknownOperandType", Message: "unknown value for operandType"},
+		core.ErrUnknownBoolOperator:                {StatusCode: 400, ErrorCode: "ErrUnknownBoolOperator", Message: "unknown value for BoolOperator"},
+		core.ErrUnknownConditionStatus:             {StatusCode: 400, ErrorCode: "ErrUnknownConditionStatus", Message: "invalid state: unknown value for ConditionStatus"},
+		core.ErrUnknownPredictionStateValue:        {StatusCode: 400, ErrorCode: "ErrUnknownPredictionStateValue", Message: "invalid state: unknown value for PredictionStateValue"},
+		core.ErrInvalidOperand:                     {StatusCode: 400, ErrorCode: "ErrInvalidOperand", Message: "invalid operand"},
+		core.ErrEmptyQuoteAsset:                    {StatusCode: 400, ErrorCode: "ErrEmptyQuoteAsset", Message: "quote asset cannot be empty"},
+		core.ErrNonEmptyQuoteAssetOnNonCoin:        {StatusCode: 400, ErrorCode: "ErrNonEmptyQuoteAssetOnNonCoin", Message: "quote asset must be empty for non-coin operand types"},
+		core.ErrEqualBaseQuoteAssets:               {StatusCode: 400, ErrorCode: "ErrEqualBaseQuoteAssets", Message: "base asset cannot be equal to quote asset"},
+		core.ErrInvalidDuration:                    {StatusCode: 400, ErrorCode: "ErrInvalidDuration", Message: "invalid duration"},
+		core.ErrInvalidFromISO8601:                 {StatusCode: 400, ErrorCode: "ErrInvalidFromISO8601", Message: "invalid FromISO8601"},
+		core.ErrInvalidToISO8601:                   {StatusCode: 400, ErrorCode: "ErrInvalidToISO8601", Message: "invalid ToISO8601"},
+		core.ErrOneOfToISO8601ToDurationRequired:   {StatusCode: 400, ErrorCode: "ErrOneOfToISO8601ToDurationRequired", Message: "one of ToISO8601 or ToDuration is required"},
+		core.ErrInvalidConditionSyntax:             {StatusCode: 400, ErrorCode: "ErrInvalidConditionSyntax", Message: "invalid condition syntax"},
+		core.ErrUnknownConditionOperator:           {StatusCode: 400, ErrorCode: "ErrUnknownConditionOperator", Message: "unknown condition operator: supported are [>|<|>=|<=|BETWEEN...AND]"},
+		core.ErrErrorMarginRatioAbove30:            {StatusCode: 400, ErrorCode: "ErrErrorMarginRatioAbove30", Message: "error margin ratio above 30%% is not allowed"},
+		core.ErrInvalidJSON:                        {StatusCode: 400, ErrorCode: "ErrInvalidJSON", Message: "invalid JSON"},
+		core.ErrEmptyReporter:                      {StatusCode: 400, ErrorCode: "ErrEmptyReporter", Message: "reporter cannot be empty"},
+		core.ErrEmptyPostURL:                       {StatusCode: 400, ErrorCode: "ErrEmptyPostURL", Message: "postUrl cannot be empty"},
+		core.ErrEmptyPostAuthor:                    {StatusCode: 400, ErrorCode: "ErrEmptyPostAuthor", Message: "postAuthor cannot be empty"},
+		core.ErrEmptyPostedAt:                      {StatusCode: 400, ErrorCode: "ErrEmptyPostedAt", Message: "postedAt cannot be empty"},
+		core.ErrInvalidPostedAt:                    {StatusCode: 400, ErrorCode: "ErrInvalidPostedAt", Message: "postedAt must be a valid ISO8601 timestamp"},
+		core.ErrEmptyPredict:                       {StatusCode: 400, ErrorCode: "ErrEmptyPredict", Message: "main predict clause cannot be empty"},
+		core.ErrMissingRequiredPrePredictPredictIf: {StatusCode: 400, ErrorCode: "ErrMissingRequiredPrePredictPredictIf", Message: "pre-predict clause must have predictIf if it has either wrongIf or annuledIf. Otherwise, add them directly on predict clause"},
+		core.ErrBoolExprSyntaxError:                {StatusCode: 400, ErrorCode: "ErrBoolExprSyntaxError", Message: "syntax error in bool expression"},
+		core.ErrPredictionFinishedAtStartTime:      {StatusCode: 400, ErrorCode: "ErrPredictionFinishedAtStartTime", Message: "prediction is finished at start time"},
 
 		// From Market
 		common.ErrInvalidMarketPair:               {StatusCode: 400, ErrorCode: "ErrInvalidMarketPair", Message: "market pair does not exist on exchange"},
@@ -84,15 +84,15 @@ var (
 		common.ErrExchangeReturnedOutOfSyncTick:   {StatusCode: 500, ErrorCode: "ErrExchangeReturnedOutOfSyncTick", Message: "exchange returned out of sync tick"},
 		common.ErrOutOfSyncTimestampPatchingHoles: {StatusCode: 500, ErrorCode: "ErrOutOfSyncTimestampPatchingHoles", Message: "out of sync timestamp found patching holes"},
 
-		ErrInvalidRequestBody:                   {StatusCode: 400, ErrorCode: "ErrInvalidRequestBody", Message: "invalid request body"},
-		ErrInvalidRequestJSON:                   {StatusCode: 400, ErrorCode: "ErrInvalidRequestJSON", Message: "invalid request JSON"},
-		ErrStorageErrorRetrievingPredictions:    {StatusCode: 500, ErrorCode: "ErrStorageErrorRetrievingPredictions", Message: "storage had error retrieving predictions"},
-		types.ErrStorageErrorRetrievingAccounts: {StatusCode: 500, ErrorCode: "ErrStorageErrorRetrievingAccounts", Message: "storage had error retrieving accounts"},
-		ErrStorageErrorStoringPrediction:        {StatusCode: 500, ErrorCode: "ErrStorageErrorStoringPrediction", Message: "storage had error storing predictions"},
-		ErrStorageErrorStoringAccount:           {StatusCode: 500, ErrorCode: "ErrStorageErrorStoringAccount", Message: "storage had error storing accounts"},
-		ErrFailedToSerializePredictions:         {StatusCode: 500, ErrorCode: "ErrFailedToSerializePredictions", Message: "failed to serialize predictions"},
-		ErrFailedToSerializeAccount:             {StatusCode: 500, ErrorCode: "ErrFailedToSerializeAccount", Message: "failed to serialize account"},
-		ErrFailedToCompilePrediction:            {StatusCode: 500, ErrorCode: "ErrFailedToCompilePrediction", Message: "failed to compile prediction"},
-		ErrPredictionNotFound:                   {StatusCode: 404, ErrorCode: "ErrPredictionNotFound", Message: "prediction not found"},
+		ErrInvalidRequestBody:                  {StatusCode: 400, ErrorCode: "ErrInvalidRequestBody", Message: "invalid request body"},
+		ErrInvalidRequestJSON:                  {StatusCode: 400, ErrorCode: "ErrInvalidRequestJSON", Message: "invalid request JSON"},
+		ErrStorageErrorRetrievingPredictions:   {StatusCode: 500, ErrorCode: "ErrStorageErrorRetrievingPredictions", Message: "storage had error retrieving predictions"},
+		core.ErrStorageErrorRetrievingAccounts: {StatusCode: 500, ErrorCode: "ErrStorageErrorRetrievingAccounts", Message: "storage had error retrieving accounts"},
+		ErrStorageErrorStoringPrediction:       {StatusCode: 500, ErrorCode: "ErrStorageErrorStoringPrediction", Message: "storage had error storing predictions"},
+		ErrStorageErrorStoringAccount:          {StatusCode: 500, ErrorCode: "ErrStorageErrorStoringAccount", Message: "storage had error storing accounts"},
+		ErrFailedToSerializePredictions:        {StatusCode: 500, ErrorCode: "ErrFailedToSerializePredictions", Message: "failed to serialize predictions"},
+		ErrFailedToSerializeAccount:            {StatusCode: 500, ErrorCode: "ErrFailedToSerializeAccount", Message: "failed to serialize account"},
+		ErrFailedToCompilePrediction:           {StatusCode: 500, ErrorCode: "ErrFailedToCompilePrediction", Message: "failed to compile prediction"},
+		ErrPredictionNotFound:                  {StatusCode: 404, ErrorCode: "ErrPredictionNotFound", Message: "prediction not found"},
 	}
 )

--- a/api/handle_get.go
+++ b/api/handle_get.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/marianogappa/crypto-candles/candles/common"
 	"github.com/marianogappa/predictions/compiler"
+	"github.com/marianogappa/predictions/core"
 	"github.com/marianogappa/predictions/serializer"
-	"github.com/marianogappa/predictions/types"
 	"github.com/swaggest/jsonschema-go"
 	"github.com/swaggest/usecase"
 )
@@ -36,7 +36,7 @@ type apiReqGetPredictions struct {
 }
 
 func (a *API) getPredictions(req apiReqGetPredictions) apiResponse[apiResGetPredictions] {
-	filters := types.APIFilters{
+	filters := core.APIFilters{
 		Tags:                  req.Tags,
 		AuthorHandles:         req.AuthorHandles,
 		AuthorURLs:            req.AuthorURLs,

--- a/api/handle_page_prediction.go
+++ b/api/handle_page_prediction.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/marianogappa/crypto-candles/candles/common"
 	"github.com/marianogappa/predictions/compiler"
+	"github.com/marianogappa/predictions/core"
 	"github.com/marianogappa/predictions/serializer"
-	"github.com/marianogappa/predictions/types"
 	"github.com/swaggest/jsonschema-go"
 	"github.com/swaggest/usecase"
 )
@@ -50,21 +50,21 @@ func (a *API) getPagesPrediction(id string) apiResponse[apiResGetPagesPrediction
 	predictionsByUUID[UUID(mainCompilerPred.UUID)] = mainCompilerPred
 
 	// Latest Predictions
-	predictions, err := a.store.GetPredictions(types.APIFilters{}, []string{types.PredictionsPostedAtDesc.String()}, 10, 0)
+	predictions, err := a.store.GetPredictions(core.APIFilters{}, []string{core.PredictionsPostedAtDesc.String()}, 10, 0)
 	latestPredictionUUIDs, predictionsByUUID, errResp := collectPredictions(predictions, err, predictionsByUUID, mainCompilerPred)
 	if errResp != nil {
 		return *errResp
 	}
 
 	// Latest Predictions by same author URL
-	predictions, err = a.store.GetPredictions(types.APIFilters{AuthorURLs: []string{pred.PostAuthorURL}}, []string{types.PredictionsPostedAtDesc.String()}, 5, 0)
+	predictions, err = a.store.GetPredictions(core.APIFilters{AuthorURLs: []string{pred.PostAuthorURL}}, []string{core.PredictionsPostedAtDesc.String()}, 5, 0)
 	latestPredictionSameAuthorURL, predictionsByUUID, errResp := collectPredictions(predictions, err, predictionsByUUID, mainCompilerPred)
 	if errResp != nil {
 		return *errResp
 	}
 
 	// Latest Predictions by same coin
-	predictions, err = a.store.GetPredictions(types.APIFilters{Tags: []string{pred.CalculateMainCoin().Str}}, []string{types.PredictionsPostedAtDesc.String()}, 5, 0)
+	predictions, err = a.store.GetPredictions(core.APIFilters{Tags: []string{pred.CalculateMainCoin().Str}}, []string{core.PredictionsPostedAtDesc.String()}, 5, 0)
 	latestPredictionSameCoinUUID, predictionsByUUID, errResp := collectPredictions(predictions, err, predictionsByUUID, mainCompilerPred)
 	if errResp != nil {
 		return *errResp
@@ -73,9 +73,9 @@ func (a *API) getPagesPrediction(id string) apiResponse[apiResGetPagesPrediction
 	accountURLSet := map[URL]struct{}{}
 
 	// Get the top 10 Accounts by follower count
-	topAccounts, err := a.store.GetAccounts(types.APIAccountFilters{}, []string{types.AccountFollowerCountDesc.String()}, 10, 0)
+	topAccounts, err := a.store.GetAccounts(core.APIAccountFilters{}, []string{core.AccountFollowerCountDesc.String()}, 10, 0)
 	if err != nil {
-		return failWith(types.ErrStorageErrorRetrievingAccounts, err, apiResGetPagesPrediction{})
+		return failWith(core.ErrStorageErrorRetrievingAccounts, err, apiResGetPagesPrediction{})
 	}
 	top10AccountURLsByFollowerCount := []URL{}
 	for _, account := range topAccounts {
@@ -99,9 +99,9 @@ func (a *API) getPagesPrediction(id string) apiResponse[apiResGetPagesPrediction
 	}
 
 	// Get all accounts from the slice
-	allAccounts, err := a.store.GetAccounts(types.APIAccountFilters{URLs: accountURLs}, []string{}, 0, 0)
+	allAccounts, err := a.store.GetAccounts(core.APIAccountFilters{URLs: accountURLs}, []string{}, 0, 0)
 	if err != nil {
-		return failWith(types.ErrStorageErrorRetrievingAccounts, err, apiResGetPagesPrediction{})
+		return failWith(core.ErrStorageErrorRetrievingAccounts, err, apiResGetPagesPrediction{})
 	}
 
 	accountsByURL := map[URL]serializer.Account{}
@@ -127,7 +127,7 @@ func (a *API) getPagesPrediction(id string) apiResponse[apiResGetPagesPrediction
 }
 
 func collectPredictions(
-	predictions []types.Prediction,
+	predictions []core.Prediction,
 	err error,
 	predictionsByUUID map[UUID]compiler.Prediction,
 	mainPrediction compiler.Prediction,

--- a/api/handle_prediction_flags.go
+++ b/api/handle_prediction_flags.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/marianogappa/predictions/core"
 	"github.com/marianogappa/predictions/statestorage"
-	"github.com/marianogappa/predictions/types"
 	"github.com/swaggest/usecase"
 )
 
@@ -66,7 +66,7 @@ func (a *API) predictionRefetchAccount(uuid string) apiResponse[apiResStored] {
 		return failWith(ErrFailedToCompilePrediction, fmt.Errorf("%w: error fetching metadata for url: %v", ErrFailedToCompilePrediction, pred.PostURL), apiResStored{})
 	}
 
-	if _, err := a.store.UpsertAccounts([]*types.Account{&metadata.Author}); err != nil {
+	if _, err := a.store.UpsertAccounts([]*core.Account{&metadata.Author}); err != nil {
 		return failWith(ErrStorageErrorStoringAccount, fmt.Errorf("%w: error storing account: %v", ErrStorageErrorStoringAccount, err), apiResStored{})
 	}
 
@@ -92,36 +92,36 @@ func (a *API) predictionClearState(uuid string) apiResponse[apiResStored] {
 	}
 
 	pred.ClearState()
-	if _, err := a.store.UpsertPredictions([]*types.Prediction{&pred}); err != nil {
+	if _, err := a.store.UpsertPredictions([]*core.Prediction{&pred}); err != nil {
 		return failWith(ErrStorageErrorStoringPrediction, fmt.Errorf("%w: error storing prediction: %v", ErrStorageErrorStoringPrediction, err), apiResStored{})
 	}
 	return apiResponse[apiResStored]{Status: 200, Data: apiResStored{Stored: true}}
 }
 
-func getPredictionByUUIDOrURL[D any](uuid, url string, store statestorage.StateStorage, zero D) (types.Prediction, *apiResponse[D]) {
+func getPredictionByUUIDOrURL[D any](uuid, url string, store statestorage.StateStorage, zero D) (core.Prediction, *apiResponse[D]) {
 	if uuid != "" {
-		return getPredictionByFilter(types.APIFilters{UUIDs: []string{uuid}, URLs: []string{}}, store, zero)
+		return getPredictionByFilter(core.APIFilters{UUIDs: []string{uuid}, URLs: []string{}}, store, zero)
 	}
-	return getPredictionByFilter(types.APIFilters{UUIDs: []string{}, URLs: []string{url}}, store, zero)
+	return getPredictionByFilter(core.APIFilters{UUIDs: []string{}, URLs: []string{url}}, store, zero)
 }
 
-func getPredictionByUUID[D any](uuid string, store statestorage.StateStorage, zero D) (types.Prediction, *apiResponse[D]) {
-	return getPredictionByFilter(types.APIFilters{UUIDs: []string{uuid}}, store, zero)
+func getPredictionByUUID[D any](uuid string, store statestorage.StateStorage, zero D) (core.Prediction, *apiResponse[D]) {
+	return getPredictionByFilter(core.APIFilters{UUIDs: []string{uuid}}, store, zero)
 }
 
-func getPredictionByFilter[D any](filter types.APIFilters, store statestorage.StateStorage, zero D) (types.Prediction, *apiResponse[D]) {
+func getPredictionByFilter[D any](filter core.APIFilters, store statestorage.StateStorage, zero D) (core.Prediction, *apiResponse[D]) {
 	ps, err := store.GetPredictions(filter, nil, 0, 0)
 	if err != nil {
 		errResp := failWith(ErrPredictionNotFound, err, zero)
-		return types.Prediction{}, &errResp
+		return core.Prediction{}, &errResp
 	}
 	if len(ps) == 0 {
 		errResp := failWith(ErrPredictionNotFound, ErrPredictionNotFound, zero)
-		return types.Prediction{}, &errResp
+		return core.Prediction{}, &errResp
 	}
 	if len(ps) != 1 {
 		errResp := failWith(ErrFailedToCompilePrediction, fmt.Errorf("%w: expected to find exactly one prediction but found %v", ErrFailedToCompilePrediction, len(ps)), zero)
-		return types.Prediction{}, &errResp
+		return core.Prediction{}, &errResp
 	}
 	return ps[0], nil
 }

--- a/api/handle_prediction_image.go
+++ b/api/handle_prediction_image.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/marianogappa/predictions/types"
+	"github.com/marianogappa/predictions/core"
 	"github.com/swaggest/usecase"
 )
 
@@ -20,7 +20,7 @@ type apiReqGetPredictionImage struct {
 
 func (a *API) getPredictionImage(uuid string) apiResponse[apiResGetPredictionImage] {
 	preds, err := a.store.GetPredictions(
-		types.APIFilters{UUIDs: []string{uuid}},
+		core.APIFilters{UUIDs: []string{uuid}},
 		[]string{},
 		0, 0,
 	)
@@ -32,15 +32,15 @@ func (a *API) getPredictionImage(uuid string) apiResponse[apiResGetPredictionIma
 	}
 	pred := preds[0]
 	if pred.PostAuthorURL == "" {
-		return failWith(types.ErrStorageErrorRetrievingAccounts, errors.New("prediction has no postAuthorURL"), apiResGetPredictionImage{})
+		return failWith(core.ErrStorageErrorRetrievingAccounts, errors.New("prediction has no postAuthorURL"), apiResGetPredictionImage{})
 	}
 
-	accounts, err := a.store.GetAccounts(types.APIAccountFilters{URLs: []string{pred.PostAuthorURL}}, []string{}, 0, 0)
+	accounts, err := a.store.GetAccounts(core.APIAccountFilters{URLs: []string{pred.PostAuthorURL}}, []string{}, 0, 0)
 	if err != nil {
-		return failWith(types.ErrStorageErrorRetrievingAccounts, err, apiResGetPredictionImage{})
+		return failWith(core.ErrStorageErrorRetrievingAccounts, err, apiResGetPredictionImage{})
 	}
 	if len(accounts) != 1 {
-		return failWith(types.ErrStorageErrorRetrievingAccounts, err, apiResGetPredictionImage{})
+		return failWith(core.ErrStorageErrorRetrievingAccounts, err, apiResGetPredictionImage{})
 	}
 	account := accounts[0]
 

--- a/backoffice/api_client.go
+++ b/backoffice/api_client.go
@@ -3,8 +3,8 @@ package backoffice
 import (
 	"fmt"
 
+	"github.com/marianogappa/predictions/core"
 	"github.com/marianogappa/predictions/request"
-	"github.com/marianogappa/predictions/types"
 )
 
 type apiClient struct {
@@ -44,8 +44,8 @@ func (c apiClient) new(pred []byte, store bool) parsedResponse {
 }
 
 type getBody struct {
-	Filters  types.APIFilters `json:"filters"`
-	OrderBys []string         `json:"orderBys"`
+	Filters  core.APIFilters `json:"filters"`
+	OrderBys []string        `json:"orderBys"`
 }
 
 func (c apiClient) get(body getBody) parsedResponse {

--- a/backoffice/api_client_internal.go
+++ b/backoffice/api_client_internal.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/marianogappa/crypto-candles/candles/common"
 	"github.com/marianogappa/predictions/compiler"
+	"github.com/marianogappa/predictions/core"
 	"github.com/marianogappa/predictions/request"
-	"github.com/marianogappa/predictions/types"
 	"github.com/rs/zerolog/log"
 )
 
@@ -85,8 +85,8 @@ type responseData struct {
 
 func (r response) parse() parsedResponse {
 	var (
-		pred        *types.Prediction
-		preds       *[]types.Prediction
+		pred        *core.Prediction
+		preds       *[]core.Prediction
 		predSummary *predictionSummary
 		stored      = r.Data.Stored
 		pc          = compiler.NewPredictionCompiler(nil, nil)
@@ -97,7 +97,7 @@ func (r response) parse() parsedResponse {
 		pred = &p
 	}
 	if r.Data.Predictions != nil {
-		preds = &[]types.Prediction{}
+		preds = &[]core.Prediction{}
 		for _, rawPred := range *r.Data.Predictions {
 			p, _, _ := pc.Compile(rawPred)
 			(*preds) = append((*preds), p)
@@ -130,17 +130,17 @@ func (r response) parse() parsedResponse {
 type predictionSummary struct {
 	TickMap  map[string][]common.Tick `json:"tickMap"`
 	Coin     string                   `json:"coin"`
-	Goal     types.JSONFloat64        `json:"goal"`
+	Goal     core.JSONFloat64         `json:"goal"`
 	Operator string                   `json:"operator"`
-	Deadline types.ISO8601            `json:"deadline"`
+	Deadline core.ISO8601             `json:"deadline"`
 }
 type parsedResponse struct {
 	Status               int
 	ErrorMessage         string
 	InternalErrorMessage string
 	ErrorCode            string
-	Prediction           *types.Prediction
-	Predictions          *[]types.Prediction
+	Prediction           *core.Prediction
+	Predictions          *[]core.Prediction
 	PredictionSummary    *predictionSummary
 	Stored               *bool
 	Base64Image          *string

--- a/backoffice/prediction_map.go
+++ b/backoffice/prediction_map.go
@@ -7,11 +7,11 @@ import (
 	"time"
 
 	"github.com/marianogappa/crypto-candles/candles/common"
+	"github.com/marianogappa/predictions/core"
 	"github.com/marianogappa/predictions/printer"
-	"github.com/marianogappa/predictions/types"
 )
 
-func predictionToMap(p types.Prediction) map[string]interface{} {
+func predictionToMap(p core.Prediction) map[string]interface{} {
 	urlType := "UNKNOWN"
 	urlSiteSpecificID := ""
 	u, err := url.Parse(p.PostURL)
@@ -53,7 +53,7 @@ func predictionToMap(p types.Prediction) map[string]interface{} {
 	return m
 }
 
-func mapifyGiven(given map[string]*types.Condition) map[string]interface{} {
+func mapifyGiven(given map[string]*core.Condition) map[string]interface{} {
 	if given == nil {
 		return nil
 	}
@@ -64,7 +64,7 @@ func mapifyGiven(given map[string]*types.Condition) map[string]interface{} {
 	return m
 }
 
-func mapifyCondition(c *types.Condition) map[string]interface{} {
+func mapifyCondition(c *core.Condition) map[string]interface{} {
 	if c == nil {
 		return nil
 	}
@@ -107,7 +107,7 @@ func mapifyLastTick(t common.Tick) map[string]interface{} {
 	}
 }
 
-func mapifyPrePredict(prePredict types.PrePredict) map[string]interface{} {
+func mapifyPrePredict(prePredict core.PrePredict) map[string]interface{} {
 	return map[string]interface{}{
 		"WrongIf":                           mapifyBoolExpr(prePredict.WrongIf),
 		"AnnulledIf":                        mapifyBoolExpr(prePredict.AnnulledIf),
@@ -117,7 +117,7 @@ func mapifyPrePredict(prePredict types.PrePredict) map[string]interface{} {
 	}
 }
 
-func mapifyBoolExpr(b *types.BoolExpr) map[string]interface{} {
+func mapifyBoolExpr(b *core.BoolExpr) map[string]interface{} {
 	if b == nil {
 		return nil
 	}
@@ -134,7 +134,7 @@ func mapifyBoolExpr(b *types.BoolExpr) map[string]interface{} {
 	}
 }
 
-func mapifyPredict(predict types.Predict) map[string]interface{} {
+func mapifyPredict(predict core.Predict) map[string]interface{} {
 	return map[string]interface{}{
 		"WrongIf":                           mapifyBoolExpr(predict.WrongIf),
 		"AnnulledIf":                        mapifyBoolExpr(predict.AnnulledIf),
@@ -143,7 +143,7 @@ func mapifyPredict(predict types.Predict) map[string]interface{} {
 	}
 }
 
-func mapifyState(state types.PredictionState) map[string]interface{} {
+func mapifyState(state core.PredictionState) map[string]interface{} {
 	return map[string]interface{}{
 		"Status": state.Status.String(),
 		"LastTs": state.LastTs,

--- a/backoffice/ui.go
+++ b/backoffice/ui.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/rs/zerolog/log"
 
+	"github.com/marianogappa/predictions/core"
 	"github.com/marianogappa/predictions/printer"
-	"github.com/marianogappa/predictions/types"
 )
 
 const (
@@ -116,7 +116,7 @@ func (s UI) indexHandler(w http.ResponseWriter, r *http.Request) {
 		log.Fatal().Msg("Couldn't find index.hmtl")
 	}
 
-	res := s.apiClient.get(getBody{Filters: types.APIFilters{
+	res := s.apiClient.get(getBody{Filters: core.APIFilters{
 		AuthorHandles:         trim(strings.Split(rawAuthors, ",")),
 		UUIDs:                 trim(strings.Split(rawUUIDs, ",")),
 		PredictionStateValues: trim(strings.Split(rawStatuses, ",")),
@@ -130,7 +130,7 @@ func (s UI) indexHandler(w http.ResponseWriter, r *http.Request) {
 	data["GetPredictionsErrCode"] = res.ErrorCode
 	data["GetPredictionsInternalErrorMessage"] = res.InternalErrorMessage
 
-	preds := []types.Prediction{}
+	preds := []core.Prediction{}
 	if res.Predictions != nil {
 		preds = *res.Predictions
 	}
@@ -157,7 +157,7 @@ func (s UI) indexHandler(w http.ResponseWriter, r *http.Request) {
 	t.Execute(w, data)
 }
 
-func predictionToFlags(pred types.Prediction) string {
+func predictionToFlags(pred core.Prediction) string {
 	var flags string
 
 	if pred.Paused {
@@ -176,7 +176,7 @@ func predictionToFlags(pred types.Prediction) string {
 	return flags
 }
 
-func isoToAgo(iso types.ISO8601) string {
+func isoToAgo(iso core.ISO8601) string {
 	tm, _ := iso.Time()
 	dur := time.Since(tm)
 	if dur < 1*time.Minute {
@@ -197,13 +197,13 @@ func isoToAgo(iso types.ISO8601) string {
 	return fmt.Sprintf("%v months ago", int(dur/(24*30*time.Hour)))
 }
 
-func predictionValueToEmoji(v types.PredictionStateValue) string {
+func predictionValueToEmoji(v core.PredictionStateValue) string {
 	switch v {
-	case types.ANNULLED:
+	case core.ANNULLED:
 		return "🏳️"
-	case types.CORRECT:
+	case core.CORRECT:
 		return "✅"
-	case types.INCORRECT:
+	case core.INCORRECT:
 		return "❌"
 	default:
 		return "⏳"
@@ -248,7 +248,7 @@ func (s UI) predictionHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if res.Status == 200 {
-		res = s.apiClient.get(getBody{Filters: types.APIFilters{
+		res = s.apiClient.get(getBody{Filters: core.APIFilters{
 			UUIDs: []string{uuid},
 		}})
 	}
@@ -287,7 +287,7 @@ func (s UI) predictionPageHandler(w http.ResponseWriter, r *http.Request) {
 		log.Fatal().Msg("Couldn't find prediction.html")
 	}
 
-	res := s.apiClient.predictionPage(getBody{Filters: types.APIFilters{
+	res := s.apiClient.predictionPage(getBody{Filters: core.APIFilters{
 		URLs: []string{url},
 	}})
 

--- a/compiler/bool_expr_parser.go
+++ b/compiler/bool_expr_parser.go
@@ -4,35 +4,35 @@ import (
 	"fmt"
 
 	"github.com/marianogappa/predictions/compiler/boolunmarshal"
-	"github.com/marianogappa/predictions/types"
+	"github.com/marianogappa/predictions/core"
 )
 
-func parseBoolExpr(s string, def map[string]*types.Condition) (*types.BoolExpr, error) {
+func parseBoolExpr(s string, def map[string]*core.Condition) (*core.BoolExpr, error) {
 	n, err := boolunmarshal.NewExprParser(s).Parse()
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", types.ErrBoolExprSyntaxError, err)
+		return nil, fmt.Errorf("%w: %v", core.ErrBoolExprSyntaxError, err)
 	}
 	return nodeToBoolExpr(n, def)
 }
 
-func nodeToBoolExpr(n boolunmarshal.Node, def map[string]*types.Condition) (*types.BoolExpr, error) {
+func nodeToBoolExpr(n boolunmarshal.Node, def map[string]*core.Condition) (*core.BoolExpr, error) {
 	switch n.TT {
 	case boolunmarshal.UNKNOWN, boolunmarshal.EOF:
-		return nil, fmt.Errorf("%w: attempted to parse an invalid/unresolved node to a bool expression", types.ErrBoolExprSyntaxError)
+		return nil, fmt.Errorf("%w: attempted to parse an invalid/unresolved node to a bool expression", core.ErrBoolExprSyntaxError)
 	case boolunmarshal.INDENTIFIER:
 		if _, ok := def[n.Token]; !ok {
-			return nil, fmt.Errorf("%w: unknown identifier '%v'...maybe you forgot to add it to the define clause", types.ErrBoolExprSyntaxError, n.Token)
+			return nil, fmt.Errorf("%w: unknown identifier '%v'...maybe you forgot to add it to the define clause", core.ErrBoolExprSyntaxError, n.Token)
 		}
-		return &types.BoolExpr{
-			Operator: types.LITERAL,
+		return &core.BoolExpr{
+			Operator: core.LITERAL,
 			Literal:  def[n.Token],
 		}, nil
 	case boolunmarshal.AND:
 		if len(n.Nodes) == 0 {
-			return nil, fmt.Errorf("%w: AND clause with zero operands", types.ErrBoolExprSyntaxError)
+			return nil, fmt.Errorf("%w: AND clause with zero operands", core.ErrBoolExprSyntaxError)
 		}
-		e := types.BoolExpr{
-			Operator: types.AND,
+		e := core.BoolExpr{
+			Operator: core.AND,
 		}
 		for _, node := range n.Nodes {
 			operand, err := nodeToBoolExpr(node, def)
@@ -44,10 +44,10 @@ func nodeToBoolExpr(n boolunmarshal.Node, def map[string]*types.Condition) (*typ
 		return &e, nil
 	case boolunmarshal.OR:
 		if len(n.Nodes) == 0 {
-			return nil, fmt.Errorf("%w: OR clause with zero operands", types.ErrBoolExprSyntaxError)
+			return nil, fmt.Errorf("%w: OR clause with zero operands", core.ErrBoolExprSyntaxError)
 		}
-		e := types.BoolExpr{
-			Operator: types.OR,
+		e := core.BoolExpr{
+			Operator: core.OR,
 		}
 		for _, node := range n.Nodes {
 			operand, err := nodeToBoolExpr(node, def)
@@ -59,16 +59,16 @@ func nodeToBoolExpr(n boolunmarshal.Node, def map[string]*types.Condition) (*typ
 		return &e, nil
 	case boolunmarshal.NOT:
 		if len(n.Nodes) != 1 {
-			return nil, fmt.Errorf("%w: NOT clause must have exactly one operand", types.ErrBoolExprSyntaxError)
+			return nil, fmt.Errorf("%w: NOT clause must have exactly one operand", core.ErrBoolExprSyntaxError)
 		}
 		operand, err := nodeToBoolExpr(n.Nodes[0], def)
 		if err != nil {
 			return nil, err
 		}
-		return &types.BoolExpr{
-			Operator: types.NOT,
-			Operands: []*types.BoolExpr{operand},
+		return &core.BoolExpr{
+			Operator: core.NOT,
+			Operands: []*core.BoolExpr{operand},
 		}, nil
 	}
-	return nil, fmt.Errorf("%w: unknown token %v", types.ErrBoolExprSyntaxError, n.Token)
+	return nil, fmt.Errorf("%w: unknown token %v", core.ErrBoolExprSyntaxError, n.Token)
 }

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/marianogappa/predictions/core"
 	"github.com/marianogappa/predictions/metadatafetcher"
 	mfTypes "github.com/marianogappa/predictions/metadatafetcher/types"
-	"github.com/marianogappa/predictions/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -18,9 +18,9 @@ func tp(s string) time.Time {
 	return t
 }
 
-func tpToISO(s string) types.ISO8601 {
+func tpToISO(s string) core.ISO8601 {
 	t, _ := time.Parse("2006-01-02 15:04:05", s)
-	return types.ISO8601(t.Format(time.RFC3339))
+	return core.ISO8601(t.Format(time.RFC3339))
 }
 
 func TestParseDuration(t *testing.T) {
@@ -135,18 +135,18 @@ func TestMapOperand(t *testing.T) {
 	tss := []struct {
 		raw      string
 		err      error
-		expected types.Operand
+		expected core.Operand
 	}{
 		{
 			raw:      "",
-			err:      types.ErrInvalidOperand,
-			expected: types.Operand{},
+			err:      core.ErrInvalidOperand,
+			expected: core.Operand{},
 		},
 		{
 			raw: "1.1",
 			err: nil,
-			expected: types.Operand{
-				Type:       types.NUMBER,
+			expected: core.Operand{
+				Type:       core.NUMBER,
 				Provider:   "",
 				QuoteAsset: "",
 				BaseAsset:  "",
@@ -156,19 +156,19 @@ func TestMapOperand(t *testing.T) {
 		},
 		{
 			raw:      "COIN:BINANCE:BTC:USDT",
-			err:      types.ErrInvalidOperand,
-			expected: types.Operand{},
+			err:      core.ErrInvalidOperand,
+			expected: core.Operand{},
 		},
 		{
 			raw:      "COIN:BINANCE:BTC-BTC",
-			err:      types.ErrEqualBaseQuoteAssets,
-			expected: types.Operand{},
+			err:      core.ErrEqualBaseQuoteAssets,
+			expected: core.Operand{},
 		},
 		{
 			raw: "COIN:BINANCE:BTC-USDT",
 			err: nil,
-			expected: types.Operand{
-				Type:       types.COIN,
+			expected: core.Operand{
+				Type:       core.COIN,
 				Provider:   "BINANCE",
 				BaseAsset:  "BTC",
 				QuoteAsset: "USDT",
@@ -178,17 +178,17 @@ func TestMapOperand(t *testing.T) {
 		},
 		{
 			raw: "COIN:BINANCE:BTC",
-			err: types.ErrEmptyQuoteAsset,
+			err: core.ErrEmptyQuoteAsset,
 		},
 		{
 			raw: "MARKETCAP:MESSARI:BTC-USDT",
-			err: types.ErrNonEmptyQuoteAssetOnNonCoin,
+			err: core.ErrNonEmptyQuoteAssetOnNonCoin,
 		},
 		{
 			raw: "MARKETCAP:MESSARI:BTC",
 			err: nil,
-			expected: types.Operand{
-				Type:      types.MARKETCAP,
+			expected: core.Operand{
+				Type:      core.MARKETCAP,
 				Provider:  "MESSARI",
 				BaseAsset: "BTC",
 				Number:    0,
@@ -227,9 +227,9 @@ func TestMapOperands(t *testing.T) {
 		t.FailNow()
 	}
 
-	expected := []types.Operand{
+	expected := []core.Operand{
 		{
-			Type:       types.COIN,
+			Type:       core.COIN,
 			Provider:   "BINANCE",
 			BaseAsset:  "BTC",
 			QuoteAsset: "USDT",
@@ -237,7 +237,7 @@ func TestMapOperands(t *testing.T) {
 			Str:        "COIN:BINANCE:BTC-USDT",
 		},
 		{
-			Type:   types.NUMBER,
+			Type:   core.NUMBER,
 			Number: 1.1,
 			Str:    "1.1",
 		},
@@ -248,8 +248,8 @@ func TestMapOperands(t *testing.T) {
 	}
 
 	_, err = mapOperands([]string{"", "1.1"})
-	if !errors.Is(err, types.ErrInvalidOperand) {
-		t.Errorf("expected %v but got: %v", types.ErrInvalidOperand, err)
+	if !errors.Is(err, core.ErrInvalidOperand) {
+		t.Errorf("expected %v but got: %v", core.ErrInvalidOperand, err)
 		t.FailNow()
 	}
 }
@@ -258,7 +258,7 @@ func TestMapFromTs(t *testing.T) {
 	tss := []struct {
 		name     string
 		cond     Condition
-		postedAt types.ISO8601
+		postedAt core.ISO8601
 		err      error
 		expected int
 	}{
@@ -273,7 +273,7 @@ func TestMapFromTs(t *testing.T) {
 			name:     "Invalid dates fail",
 			cond:     Condition{FromISO8601: "invalid date"},
 			postedAt: tpToISO("2020-01-02 00:00:00"),
-			err:      types.ErrInvalidFromISO8601,
+			err:      core.ErrInvalidFromISO8601,
 			expected: 0,
 		},
 		{
@@ -320,13 +320,13 @@ func TestMapToTs(t *testing.T) {
 			name:   "All empty",
 			cond:   Condition{ToISO8601: "", ToDuration: ""},
 			fromTs: int(tp("2020-01-02 00:00:00").Unix()),
-			err:    types.ErrOneOfToISO8601ToDurationRequired,
+			err:    core.ErrOneOfToISO8601ToDurationRequired,
 		},
 		{
 			name:   "Invalid duration",
 			cond:   Condition{ToISO8601: "", ToDuration: "invalid"},
 			fromTs: int(tp("2020-01-02 00:00:00").Unix()),
-			err:    types.ErrInvalidDuration,
+			err:    core.ErrInvalidDuration,
 		},
 		{
 			name:     "Uses FromISO8601+ToDuration when ToISO8601",
@@ -339,7 +339,7 @@ func TestMapToTs(t *testing.T) {
 			name:   "Invalid dates fail",
 			cond:   Condition{ToISO8601: "invalid date", ToDuration: "2w"},
 			fromTs: int(tp("2020-01-02 00:00:00").Unix()),
-			err:    types.ErrInvalidToISO8601,
+			err:    core.ErrInvalidToISO8601,
 		},
 		{
 			name:     "Valid dates take precedence over everything",
@@ -378,51 +378,51 @@ func TestMapCondition(t *testing.T) {
 		name     string
 		cond     Condition
 		condName string
-		postedAt types.ISO8601
+		postedAt core.ISO8601
 		err      error
-		expected types.Condition
+		expected core.Condition
 	}{
 		{
 			name:     "Invalid condition syntax",
 			cond:     Condition{Condition: "invalid condition syntax!!"},
 			condName: "main",
 			postedAt: tpToISO("2020-01-02 00:00:00"),
-			err:      types.ErrInvalidConditionSyntax,
+			err:      core.ErrInvalidConditionSyntax,
 		},
 		{
 			name:     "Empty quote asset",
 			cond:     Condition{Condition: "COIN:BINANCE:BTC >= 60000"},
 			condName: "main",
 			postedAt: tpToISO("2020-01-02 00:00:00"),
-			err:      types.ErrEmptyQuoteAsset,
+			err:      core.ErrEmptyQuoteAsset,
 		},
 		{
 			name:     "Unknown condition operator",
 			cond:     Condition{Condition: "COIN:BINANCE:BTC-USDT != 60000"},
 			condName: "main",
 			postedAt: tpToISO("2020-01-02 00:00:00"),
-			err:      types.ErrUnknownConditionOperator,
+			err:      core.ErrUnknownConditionOperator,
 		},
 		{
 			name:     "Unknown condition operator",
 			cond:     Condition{Condition: "COIN:BINANCE:BTC-USDT >= 60000", ErrorMarginRatio: 0.4},
 			condName: "main",
 			postedAt: tpToISO("2020-01-02 00:00:00"),
-			err:      types.ErrErrorMarginRatioAbove30,
+			err:      core.ErrErrorMarginRatioAbove30,
 		},
 		{
 			name:     "Unknown condition state value",
 			cond:     Condition{Condition: "COIN:BINANCE:BTC-USDT >= 60000", State: ConditionState{Value: "???"}},
 			condName: "main",
 			postedAt: tpToISO("2020-01-02 00:00:00"),
-			err:      types.ErrUnknownConditionStateValue,
+			err:      core.ErrUnknownConditionStateValue,
 		},
 		{
 			name:     "Unknown condition status",
 			cond:     Condition{Condition: "COIN:BINANCE:BTC-USDT >= 60000", State: ConditionState{Value: "UNDECIDED", Status: "???"}},
 			condName: "main",
 			postedAt: tpToISO("2020-01-02 00:00:00"),
-			err:      types.ErrUnknownConditionStatus,
+			err:      core.ErrUnknownConditionStatus,
 		},
 		{
 			name: "Invalid FromISO8601",
@@ -433,7 +433,7 @@ func TestMapCondition(t *testing.T) {
 			},
 			condName: "main",
 			postedAt: tpToISO("2020-01-02 00:00:00"),
-			err:      types.ErrInvalidFromISO8601,
+			err:      core.ErrInvalidFromISO8601,
 		},
 		{
 			name: "Invalid ToISO8601",
@@ -444,7 +444,7 @@ func TestMapCondition(t *testing.T) {
 			},
 			condName: "main",
 			postedAt: tpToISO("2020-01-02 00:00:00"),
-			err:      types.ErrInvalidToISO8601,
+			err:      core.ErrInvalidToISO8601,
 		},
 		{
 			name: "Happy case",
@@ -456,24 +456,24 @@ func TestMapCondition(t *testing.T) {
 			condName: "main",
 			postedAt: tpToISO("2020-01-02 00:00:00"),
 			err:      nil,
-			expected: types.Condition{
+			expected: core.Condition{
 				Name:     "main",
 				Operator: "BETWEEN",
-				Operands: []types.Operand{
+				Operands: []core.Operand{
 					{
-						Type:       types.COIN,
+						Type:       core.COIN,
 						Provider:   "BINANCE",
 						QuoteAsset: "USDT",
 						BaseAsset:  "BTC",
 						Str:        "COIN:BINANCE:BTC-USDT",
 					},
 					{
-						Type:   types.NUMBER,
+						Type:   core.NUMBER,
 						Number: 60000,
 						Str:    "60000",
 					},
 					{
-						Type:   types.NUMBER,
+						Type:   core.NUMBER,
 						Number: 70000,
 						Str:    "70000",
 					},
@@ -482,7 +482,7 @@ func TestMapCondition(t *testing.T) {
 				ToTs:             int(tp("2020-01-03 00:00:00").Unix()),
 				ToDuration:       "",
 				Assumed:          nil,
-				State:            types.ConditionState{Value: types.UNDECIDED, Status: types.STARTED},
+				State:            core.ConditionState{Value: core.UNDECIDED, Status: core.STARTED},
 				ErrorMarginRatio: 0,
 			},
 		},
@@ -524,14 +524,14 @@ func TestMapBoolExprNil(t *testing.T) {
 func TestMapBoolExprInvalid(t *testing.T) {
 	invalid := "invalid"
 	_, err := mapBoolExpr(&invalid, nil)
-	if !errors.Is(err, types.ErrBoolExprSyntaxError) {
+	if !errors.Is(err, core.ErrBoolExprSyntaxError) {
 		t.Errorf("err should have been ErrBoolExprSyntaxError but was %v", err)
 	}
 }
 
 func TestMapBoolExprHappyCase(t *testing.T) {
 	valid := "main"
-	_, err := mapBoolExpr(&valid, map[string]*types.Condition{"main": {}})
+	_, err := mapBoolExpr(&valid, map[string]*core.Condition{"main": {}})
 	if err != nil {
 		t.Errorf("err should have been nil but was %v", err)
 	}
@@ -562,63 +562,63 @@ func TestCompile(t *testing.T) {
 		timeNow              func() time.Time
 		postMetadataFetchErr error
 		err                  error
-		expected             types.Prediction
+		expected             core.Prediction
 	}{
 		{
 			name:     "Invalid JSON",
 			pred:     "invalid!!",
-			err:      types.ErrInvalidJSON,
-			expected: types.Prediction{},
+			err:      core.ErrInvalidJSON,
+			expected: core.Prediction{},
 		},
 		{
 			name:     "Empty reporter",
 			pred:     `{"reporter": ""}`,
-			err:      types.ErrEmptyReporter,
-			expected: types.Prediction{},
+			err:      core.ErrEmptyReporter,
+			expected: core.Prediction{},
 		},
 		{
 			name:     "Empty postUrl",
 			pred:     `{"reporter": "admin", "postUrl": ""}`,
-			err:      types.ErrEmptyPostURL,
-			expected: types.Prediction{},
+			err:      core.ErrEmptyPostURL,
+			expected: core.Prediction{},
 		},
 		{
 			name:                 "Metadata fetcher returns error",
 			pred:                 `{"reporter": "admin", "postUrl": "https://twitter.com/CryptoCapo_/status/1491357566974054400"}`,
-			postMetadataFetchErr: types.ErrEmptyPostAuthor,
-			err:                  types.ErrEmptyPostAuthor,
-			expected:             types.Prediction{},
+			postMetadataFetchErr: core.ErrEmptyPostAuthor,
+			err:                  core.ErrEmptyPostAuthor,
+			expected:             core.Prediction{},
 		},
 		{
 			name:                 "Metadata fetcher returns postAuthor but not postedAt",
 			pred:                 `{"reporter": "admin", "postUrl": "https://twitter.com/CryptoCapo_/status/1491357566974054400"}`,
 			postMetadataFetchErr: nil,
 			postMetadata: mfTypes.PostMetadata{
-				Author:        types.Account{Handle: "CryptoCapo_"},
-				PostCreatedAt: types.ISO8601(""),
+				Author:        core.Account{Handle: "CryptoCapo_"},
+				PostCreatedAt: core.ISO8601(""),
 			},
-			err:      types.ErrEmptyPostedAt,
-			expected: types.Prediction{},
+			err:      core.ErrEmptyPostedAt,
+			expected: core.Prediction{},
 		},
 		{
 			name:                 "Metadata fetcher returns postAuthor and invalid postedAt",
 			pred:                 `{"reporter": "admin", "postUrl": "https://twitter.com/CryptoCapo_/status/1491357566974054400"}`,
 			postMetadataFetchErr: nil,
 			postMetadata: mfTypes.PostMetadata{
-				Author:        types.Account{Handle: "CryptoCapo_"},
-				PostCreatedAt: types.ISO8601("INVALID!!!"),
+				Author:        core.Account{Handle: "CryptoCapo_"},
+				PostCreatedAt: core.ISO8601("INVALID!!!"),
 			},
-			err:      types.ErrInvalidPostedAt,
-			expected: types.Prediction{},
+			err:      core.ErrInvalidPostedAt,
+			expected: core.Prediction{},
 		},
 		{
 			name: "Empty main predict",
 			pred: `{"reporter": "admin", "postUrl": "https://twitter.com/CryptoCapo_/status/1491357566974054400"}`,
 			postMetadata: mfTypes.PostMetadata{
-				Author:        types.Account{Handle: "CryptoCapo_"},
+				Author:        core.Account{Handle: "CryptoCapo_"},
 				PostCreatedAt: tpToISO("2020-01-02 00:00:00"),
 			},
-			err: types.ErrEmptyPredict,
+			err: core.ErrEmptyPredict,
 		},
 		{
 			name: "Error mapping condition: no ToISO8601",
@@ -636,11 +636,11 @@ func TestCompile(t *testing.T) {
 			}`,
 			postMetadataFetchErr: nil,
 			postMetadata: mfTypes.PostMetadata{
-				Author:        types.Account{Handle: "CryptoCapo_"},
+				Author:        core.Account{Handle: "CryptoCapo_"},
 				PostCreatedAt: tpToISO("2020-01-02 00:00:00"),
 			},
-			err:      types.ErrOneOfToISO8601ToDurationRequired,
-			expected: types.Prediction{},
+			err:      core.ErrOneOfToISO8601ToDurationRequired,
+			expected: core.Prediction{},
 		},
 		{
 			name: "Error mapping prePredict.predict: ErrBoolExprSyntaxError",
@@ -662,11 +662,11 @@ func TestCompile(t *testing.T) {
 			}`,
 			postMetadataFetchErr: nil,
 			postMetadata: mfTypes.PostMetadata{
-				Author:        types.Account{Handle: "CryptoCapo_"},
+				Author:        core.Account{Handle: "CryptoCapo_"},
 				PostCreatedAt: tpToISO("2020-01-02 00:00:00"),
 			},
-			err:      types.ErrBoolExprSyntaxError,
-			expected: types.Prediction{},
+			err:      core.ErrBoolExprSyntaxError,
+			expected: core.Prediction{},
 		},
 		{
 			name: "Error mapping prePredict.wrongIf: ErrBoolExprSyntaxError",
@@ -689,11 +689,11 @@ func TestCompile(t *testing.T) {
 			}`,
 			postMetadataFetchErr: nil,
 			postMetadata: mfTypes.PostMetadata{
-				Author:        types.Account{Handle: "CryptoCapo_"},
+				Author:        core.Account{Handle: "CryptoCapo_"},
 				PostCreatedAt: tpToISO("2020-01-02 00:00:00"),
 			},
-			err:      types.ErrBoolExprSyntaxError,
-			expected: types.Prediction{},
+			err:      core.ErrBoolExprSyntaxError,
+			expected: core.Prediction{},
 		},
 		{
 			name: "Error mapping prePredict.annulledIf: ErrBoolExprSyntaxError",
@@ -717,11 +717,11 @@ func TestCompile(t *testing.T) {
 			}`,
 			postMetadataFetchErr: nil,
 			postMetadata: mfTypes.PostMetadata{
-				Author:        types.Account{Handle: "CryptoCapo_"},
+				Author:        core.Account{Handle: "CryptoCapo_"},
 				PostCreatedAt: tpToISO("2020-01-02 00:00:00"),
 			},
-			err:      types.ErrBoolExprSyntaxError,
-			expected: types.Prediction{},
+			err:      core.ErrBoolExprSyntaxError,
+			expected: core.Prediction{},
 		},
 		{
 			name: "Must have prePredict.predict if it has prePredict.wrongIf",
@@ -740,11 +740,11 @@ func TestCompile(t *testing.T) {
 			}`,
 			postMetadataFetchErr: nil,
 			postMetadata: mfTypes.PostMetadata{
-				Author:        types.Account{Handle: "CryptoCapo_"},
+				Author:        core.Account{Handle: "CryptoCapo_"},
 				PostCreatedAt: tpToISO("2020-01-02 00:00:00"),
 			},
-			err:      types.ErrMissingRequiredPrePredictPredictIf,
-			expected: types.Prediction{},
+			err:      core.ErrMissingRequiredPrePredictPredictIf,
+			expected: core.Prediction{},
 		},
 		{
 			name: "Must have prePredict.predict if it has prePredict.annulledIf",
@@ -763,11 +763,11 @@ func TestCompile(t *testing.T) {
 			}`,
 			postMetadataFetchErr: nil,
 			postMetadata: mfTypes.PostMetadata{
-				Author:        types.Account{Handle: "CryptoCapo_"},
+				Author:        core.Account{Handle: "CryptoCapo_"},
 				PostCreatedAt: tpToISO("2020-01-02 00:00:00"),
 			},
-			err:      types.ErrMissingRequiredPrePredictPredictIf,
-			expected: types.Prediction{},
+			err:      core.ErrMissingRequiredPrePredictPredictIf,
+			expected: core.Prediction{},
 		},
 		{
 			name: "Error mapping predict.wrongIf: ErrBoolExprSyntaxError",
@@ -787,11 +787,11 @@ func TestCompile(t *testing.T) {
 			}`,
 			postMetadataFetchErr: nil,
 			postMetadata: mfTypes.PostMetadata{
-				Author:        types.Account{Handle: "CryptoCapo_"},
+				Author:        core.Account{Handle: "CryptoCapo_"},
 				PostCreatedAt: tpToISO("2020-01-02 00:00:00"),
 			},
-			err:      types.ErrBoolExprSyntaxError,
-			expected: types.Prediction{},
+			err:      core.ErrBoolExprSyntaxError,
+			expected: core.Prediction{},
 		},
 		{
 			name: "Error mapping predict.annulledIf: ErrBoolExprSyntaxError",
@@ -811,11 +811,11 @@ func TestCompile(t *testing.T) {
 			}`,
 			postMetadataFetchErr: nil,
 			postMetadata: mfTypes.PostMetadata{
-				Author:        types.Account{Handle: "CryptoCapo_"},
+				Author:        core.Account{Handle: "CryptoCapo_"},
 				PostCreatedAt: tpToISO("2020-01-02 00:00:00"),
 			},
-			err:      types.ErrBoolExprSyntaxError,
-			expected: types.Prediction{},
+			err:      core.ErrBoolExprSyntaxError,
+			expected: core.Prediction{},
 		},
 		{
 			name: "Error mapping predict.predict: ErrBoolExprSyntaxError",
@@ -834,11 +834,11 @@ func TestCompile(t *testing.T) {
 			}`,
 			postMetadataFetchErr: nil,
 			postMetadata: mfTypes.PostMetadata{
-				Author:        types.Account{Handle: "CryptoCapo_"},
+				Author:        core.Account{Handle: "CryptoCapo_"},
 				PostCreatedAt: tpToISO("2020-01-02 00:00:00"),
 			},
-			err:      types.ErrBoolExprSyntaxError,
-			expected: types.Prediction{},
+			err:      core.ErrBoolExprSyntaxError,
+			expected: core.Prediction{},
 		},
 		{
 			name: "Error mapping prediction state: ErrUnknownConditionStatus",
@@ -865,11 +865,11 @@ func TestCompile(t *testing.T) {
 			}`,
 			postMetadataFetchErr: nil,
 			postMetadata: mfTypes.PostMetadata{
-				Author:        types.Account{Handle: "CryptoCapo_"},
+				Author:        core.Account{Handle: "CryptoCapo_"},
 				PostCreatedAt: tpToISO("2020-01-02 00:00:00"),
 			},
-			err:      types.ErrUnknownConditionStatus,
-			expected: types.Prediction{},
+			err:      core.ErrUnknownConditionStatus,
+			expected: core.Prediction{},
 		},
 		{
 			name: "Error mapping prediction state: ErrUnknownPredictionStateValue",
@@ -897,11 +897,11 @@ func TestCompile(t *testing.T) {
 			}`,
 			postMetadataFetchErr: nil,
 			postMetadata: mfTypes.PostMetadata{
-				Author:        types.Account{Handle: "CryptoCapo_"},
+				Author:        core.Account{Handle: "CryptoCapo_"},
 				PostCreatedAt: tpToISO("2020-01-02 00:00:00"),
 			},
-			err:      types.ErrUnknownPredictionStateValue,
-			expected: types.Prediction{},
+			err:      core.ErrUnknownPredictionStateValue,
+			expected: core.Prediction{},
 		},
 		{
 			name: "Does not overwrite author & created at with metadata, when fields are set",
@@ -922,42 +922,42 @@ func TestCompile(t *testing.T) {
 			}`,
 			postMetadataFetchErr: nil,
 			postMetadata: mfTypes.PostMetadata{
-				Author:        types.Account{Handle: "CryptoCapo_"},
+				Author:        core.Account{Handle: "CryptoCapo_"},
 				PostCreatedAt: tpToISO("2020-01-02 00:00:00"),
 			},
 			timeNow: func() time.Time { return tp("2020-01-03 00:00:00") },
 			err:     nil,
-			expected: types.Prediction{
+			expected: core.Prediction{
 				Version:    "1.0.0",
 				CreatedAt:  tpToISO("2020-01-03 00:00:00"),
 				Reporter:   "admin",
 				PostAuthor: "NOT CryptoCapo!",
 				PostText:   "",
-				PostedAt:   types.ISO8601("2022-02-09T10:25:26.000Z"),
+				PostedAt:   core.ISO8601("2022-02-09T10:25:26.000Z"),
 				PostURL:    "https://twitter.com/CryptoCapo_/status/1491357566974054400",
-				Given: map[string]*types.Condition{
+				Given: map[string]*core.Condition{
 					"main": {
 						Name:     "main",
 						Operator: "<=",
-						Operands: []types.Operand{
-							{Type: types.COIN, Provider: "BINANCE", BaseAsset: "ADA", QuoteAsset: "USDT", Str: "COIN:BINANCE:ADA-USDT"},
-							{Type: types.NUMBER, Number: types.JSONFloat64(0.845), Str: "0.845"},
+						Operands: []core.Operand{
+							{Type: core.COIN, Provider: "BINANCE", BaseAsset: "ADA", QuoteAsset: "USDT", Str: "COIN:BINANCE:ADA-USDT"},
+							{Type: core.NUMBER, Number: core.JSONFloat64(0.845), Str: "0.845"},
 						},
 						FromTs:     int(tp("2022-02-09 10:25:26").Unix()),
 						ToTs:       int(tp("2022-02-11 10:25:26").Unix()),
 						ToDuration: "2d",
 					},
 				},
-				Predict: types.Predict{
-					Predict: types.BoolExpr{
-						Operator: types.LITERAL,
+				Predict: core.Predict{
+					Predict: core.BoolExpr{
+						Operator: core.LITERAL,
 						Operands: nil,
-						Literal: &types.Condition{
+						Literal: &core.Condition{
 							Name:     "main",
 							Operator: "<=",
-							Operands: []types.Operand{
-								{Type: types.COIN, Provider: "BINANCE", BaseAsset: "ADA", QuoteAsset: "USDT", Str: "COIN:BINANCE:ADA-USDT"},
-								{Type: types.NUMBER, Number: types.JSONFloat64(0.845), Str: "0.845"},
+							Operands: []core.Operand{
+								{Type: core.COIN, Provider: "BINANCE", BaseAsset: "ADA", QuoteAsset: "USDT", Str: "COIN:BINANCE:ADA-USDT"},
+								{Type: core.NUMBER, Number: core.JSONFloat64(0.845), Str: "0.845"},
 							},
 							FromTs:     int(tp("2022-02-09 10:25:26").Unix()),
 							ToTs:       int(tp("2022-02-11 10:25:26").Unix()),
@@ -965,7 +965,7 @@ func TestCompile(t *testing.T) {
 						},
 					},
 				},
-				Type: types.PredictionTypeCoinOperatorFloatDeadline,
+				Type: core.PredictionTypeCoinOperatorFloatDeadline,
 			},
 		},
 		{
@@ -986,42 +986,42 @@ func TestCompile(t *testing.T) {
 			}`,
 			postMetadataFetchErr: nil,
 			postMetadata: mfTypes.PostMetadata{
-				Author:        types.Account{Handle: "CryptoCapo_"},
+				Author:        core.Account{Handle: "CryptoCapo_"},
 				PostCreatedAt: tpToISO("2020-01-02 00:00:00"),
 			},
 			timeNow: func() time.Time { return tp("2020-01-03 00:00:00") },
 			err:     nil,
-			expected: types.Prediction{
+			expected: core.Prediction{
 				Version:    "1.0.0",
 				CreatedAt:  tpToISO("2020-01-03 00:00:00"),
 				Reporter:   "admin",
 				PostAuthor: "CryptoCapo_",
 				PostText:   "",
-				PostedAt:   types.ISO8601("2022-02-09T10:25:26.000Z"),
+				PostedAt:   core.ISO8601("2022-02-09T10:25:26.000Z"),
 				PostURL:    "https://twitter.com/CryptoCapo_/status/1491357566974054400",
-				Given: map[string]*types.Condition{
+				Given: map[string]*core.Condition{
 					"main": {
 						Name:     "main",
 						Operator: "<=",
-						Operands: []types.Operand{
-							{Type: types.COIN, Provider: "BINANCE", BaseAsset: "ADA", QuoteAsset: "USDT", Str: "COIN:BINANCE:ADA-USDT"},
-							{Type: types.NUMBER, Number: types.JSONFloat64(0.845), Str: "0.845"},
+						Operands: []core.Operand{
+							{Type: core.COIN, Provider: "BINANCE", BaseAsset: "ADA", QuoteAsset: "USDT", Str: "COIN:BINANCE:ADA-USDT"},
+							{Type: core.NUMBER, Number: core.JSONFloat64(0.845), Str: "0.845"},
 						},
 						FromTs:     int(tp("2022-02-09 10:25:26").Unix()),
 						ToTs:       int(tp("2022-02-11 10:25:26").Unix()),
 						ToDuration: "2d",
 					},
 				},
-				Predict: types.Predict{
-					Predict: types.BoolExpr{
-						Operator: types.LITERAL,
+				Predict: core.Predict{
+					Predict: core.BoolExpr{
+						Operator: core.LITERAL,
 						Operands: nil,
-						Literal: &types.Condition{
+						Literal: &core.Condition{
 							Name:     "main",
 							Operator: "<=",
-							Operands: []types.Operand{
-								{Type: types.COIN, Provider: "BINANCE", BaseAsset: "ADA", QuoteAsset: "USDT", Str: "COIN:BINANCE:ADA-USDT"},
-								{Type: types.NUMBER, Number: types.JSONFloat64(0.845), Str: "0.845"},
+							Operands: []core.Operand{
+								{Type: core.COIN, Provider: "BINANCE", BaseAsset: "ADA", QuoteAsset: "USDT", Str: "COIN:BINANCE:ADA-USDT"},
+								{Type: core.NUMBER, Number: core.JSONFloat64(0.845), Str: "0.845"},
 							},
 							FromTs:     int(tp("2022-02-09 10:25:26").Unix()),
 							ToTs:       int(tp("2022-02-11 10:25:26").Unix()),
@@ -1029,7 +1029,7 @@ func TestCompile(t *testing.T) {
 						},
 					},
 				},
-				Type: types.PredictionTypeCoinOperatorFloatDeadline,
+				Type: core.PredictionTypeCoinOperatorFloatDeadline,
 			},
 		},
 	}

--- a/compiler/compiler_types.go
+++ b/compiler/compiler_types.go
@@ -2,7 +2,7 @@ package compiler
 
 import (
 	"github.com/marianogappa/crypto-candles/candles/common"
-	"github.com/marianogappa/predictions/types"
+	"github.com/marianogappa/predictions/core"
 	"github.com/swaggest/jsonschema-go"
 )
 
@@ -24,8 +24,8 @@ type PredictionState struct {
 // Condition is each of the conditions that form a prediction, e.g. "COIN:BINANCE:BTC-USDT <= 29000 within 3 weeks".
 type Condition struct {
 	Condition        string         `json:"condition" required:"true" example:"COIN:BINANCE:BTC-USDT <= 29000"`
-	FromISO8601      types.ISO8601  `json:"fromISO8601" format:"date-time" example:"2022-01-26T22:35:43Z"`
-	ToISO8601        types.ISO8601  `json:"toISO8601" format:"date-time" example:"2023-01-01T00:00:00Z"`
+	FromISO8601      core.ISO8601   `json:"fromISO8601" format:"date-time" example:"2022-01-26T22:35:43Z"`
+	ToISO8601        core.ISO8601   `json:"toISO8601" format:"date-time" example:"2023-01-01T00:00:00Z"`
 	ToDuration       string         `json:"toDuration" example:"eoy"`
 	Assumed          []string       `json:"assumed" example:"[\"toDuration\"]"`
 	State            ConditionState `json:"state"`
@@ -54,11 +54,11 @@ type Predict struct {
 type Prediction struct {
 	UUID            string               `json:"uuid" format:"uuid" description:"Prediction's primary key." example:"3a7bc95e-480d-4232-8e8b-f848d5389806"`
 	Version         string               `json:"version" description:"Set to 1.0.0." example:"1.0.0"`
-	CreatedAt       types.ISO8601        `json:"createdAt" description:"This is automatically calculated when created." format:"date-time" example:"2022-01-26T22:35:43Z"`
+	CreatedAt       core.ISO8601         `json:"createdAt" description:"This is automatically calculated when created." format:"date-time" example:"2022-01-26T22:35:43Z"`
 	Reporter        string               `json:"reporter" description:"Set to admin for now." required:"true" minLength:"1" example:"admin"`
 	PostAuthor      string               `json:"postAuthor" description:"This is automatically calculated based on the tweet/youtube video in postUrl." example:"CryptoCapo_"`
 	PostAuthorURL   string               `json:"postAuthorURL,omitempty" description:"This is automatically calculated based on the tweet/youtube video in postUrl." example:"https://twitter.com/CryptoCapo_"`
-	PostedAt        types.ISO8601        `json:"postedAt" description:"This is automatically calculated based on the tweet/youtube video in postUrl." format:"date-time" example:"2022-01-26T22:35:43Z"`
+	PostedAt        core.ISO8601         `json:"postedAt" description:"This is automatically calculated based on the tweet/youtube video in postUrl." format:"date-time" example:"2022-01-26T22:35:43Z"`
 	PostURL         string               `json:"postUrl" description:"The tweet/youtube video's URL." required:"true" format:"uri" example:"https://twitter.com/CryptoCapo_/status/1486467919064322051"`
 	Given           map[string]Condition `json:"given,omitempty" description:"The conditions that form this prediction." required:"true"`
 	PrePredict      *PrePredict          `json:"prePredict,omitempty"`
@@ -80,32 +80,32 @@ type PredictionSummary struct {
 	OtherCoin string `json:"otherCoin,omitempty"`
 
 	// Only in "PredictionTypeCoinOperatorFloatDeadline" type
-	Goal                                    types.JSONFloat64 `json:"goal,omitempty"`
-	GoalWithError                           types.JSONFloat64 `json:"goalWithError,omitempty"`
-	EndedAtTruncatedDueToResultInvalidation types.ISO8601     `json:"endedAtTruncatedDueToResultInvalidation,omitempty"`
+	Goal                                    core.JSONFloat64 `json:"goal,omitempty"`
+	GoalWithError                           core.JSONFloat64 `json:"goalWithError,omitempty"`
+	EndedAtTruncatedDueToResultInvalidation core.ISO8601     `json:"endedAtTruncatedDueToResultInvalidation,omitempty"`
 
 	// Only in "PredictionTypeCoinWillReachInvalidatedIfItReaches"
-	InvalidatedIfItReaches types.JSONFloat64 `json:"invalidatedIfItReaches,omitempty"`
+	InvalidatedIfItReaches core.JSONFloat64 `json:"invalidatedIfItReaches,omitempty"`
 
 	// Only in "PredictionWillRange type"
-	RangeLow           types.JSONFloat64 `json:"rangeLow,omitempty"`
-	RangeLowWithError  types.JSONFloat64 `json:"rangeLowWithError,omitempty"`
-	RangeHigh          types.JSONFloat64 `json:"rangeHigh,omitempty"`
-	RangeHighWithError types.JSONFloat64 `json:"rangeHighWithError,omitempty"`
+	RangeLow           core.JSONFloat64 `json:"rangeLow,omitempty"`
+	RangeLowWithError  core.JSONFloat64 `json:"rangeLowWithError,omitempty"`
+	RangeHigh          core.JSONFloat64 `json:"rangeHigh,omitempty"`
+	RangeHighWithError core.JSONFloat64 `json:"rangeHighWithError,omitempty"`
 
 	// Only in "PredictionWillReachBeforeItReaches type"
-	WillReach                types.JSONFloat64 `json:"willReach,omitempty"`
-	WillReachWithError       types.JSONFloat64 `json:"willReachWithError,omitempty"`
-	BeforeItReaches          types.JSONFloat64 `json:"beforeItReaches,omitempty"`
-	BeforeItReachesWithError types.JSONFloat64 `json:"beforeItReachesWithError,omitempty"`
+	WillReach                core.JSONFloat64 `json:"willReach,omitempty"`
+	WillReachWithError       core.JSONFloat64 `json:"willReachWithError,omitempty"`
+	BeforeItReaches          core.JSONFloat64 `json:"beforeItReaches,omitempty"`
+	BeforeItReachesWithError core.JSONFloat64 `json:"beforeItReachesWithError,omitempty"`
 
 	// In all prediction types
 	CandlestickMap   map[string][]common.Candlestick `json:"candlestickMap,omitempty"`
 	Coin             string                          `json:"coin,omitempty"`
-	ErrorMarginRatio types.JSONFloat64               `json:"errorMarginRatio,omitempty"`
+	ErrorMarginRatio core.JSONFloat64                `json:"errorMarginRatio,omitempty"`
 	Operator         string                          `json:"operator,omitempty"`
-	Deadline         types.ISO8601                   `json:"deadline,omitempty"`
-	EndedAt          types.ISO8601                   `json:"endedAt,omitempty"`
+	Deadline         core.ISO8601                    `json:"deadline,omitempty"`
+	EndedAt          core.ISO8601                    `json:"endedAt,omitempty"`
 	PredictionType   string                          `json:"predictionType,omitempty"`
 }
 

--- a/compiler/prediction_type.go
+++ b/compiler/prediction_type.go
@@ -1,72 +1,70 @@
 package compiler
 
-import (
-	"github.com/marianogappa/predictions/types"
-)
+import "github.com/marianogappa/predictions/core"
 
 // CalculatePredictionType infers the prediction type by looking at its structure.
-func CalculatePredictionType(pred types.Prediction) types.PredictionType {
+func CalculatePredictionType(pred core.Prediction) core.PredictionType {
 	for predictionType, is := range predictionTypes {
 		if is(pred) {
 			return predictionType
 		}
 	}
-	return types.PredictionTypeUnsupported
+	return core.PredictionTypeUnsupported
 }
 
 var (
-	predictionTypes = map[types.PredictionType]func(types.Prediction) bool{
-		types.PredictionTypeCoinOperatorFloatDeadline: func(pred types.Prediction) bool {
+	predictionTypes = map[core.PredictionType]func(core.Prediction) bool{
+		core.PredictionTypeCoinOperatorFloatDeadline: func(pred core.Prediction) bool {
 			return pred.PrePredict.Predict == nil && pred.PrePredict.AnnulledIf == nil &&
 				pred.PrePredict.WrongIf == nil && pred.Predict.AnnulledIf == nil && pred.Predict.WrongIf == nil &&
-				pred.Predict.Predict.Operator == types.LITERAL && len(pred.Predict.Predict.Literal.Operands) == 2 &&
-				pred.Predict.Predict.Literal.Operands[0].Type == types.COIN &&
-				pred.Predict.Predict.Literal.Operands[1].Type == types.NUMBER
+				pred.Predict.Predict.Operator == core.LITERAL && len(pred.Predict.Predict.Literal.Operands) == 2 &&
+				pred.Predict.Predict.Literal.Operands[0].Type == core.COIN &&
+				pred.Predict.Predict.Literal.Operands[1].Type == core.NUMBER
 		},
-		types.PredictionTypeCoinWillReachInvalidatedIfItReaches: func(pred types.Prediction) bool {
+		core.PredictionTypeCoinWillReachInvalidatedIfItReaches: func(pred core.Prediction) bool {
 			return pred.PrePredict.Predict == nil && pred.PrePredict.AnnulledIf == nil &&
 				pred.PrePredict.WrongIf == nil && pred.Predict.AnnulledIf != nil && pred.Predict.WrongIf == nil &&
 
 				// Predict section
-				pred.Predict.Predict.Operator == types.LITERAL && len(pred.Predict.Predict.Literal.Operands) == 2 &&
-				pred.Predict.Predict.Literal.Operands[0].Type == types.COIN &&
-				pred.Predict.Predict.Literal.Operands[1].Type == types.NUMBER &&
+				pred.Predict.Predict.Operator == core.LITERAL && len(pred.Predict.Predict.Literal.Operands) == 2 &&
+				pred.Predict.Predict.Literal.Operands[0].Type == core.COIN &&
+				pred.Predict.Predict.Literal.Operands[1].Type == core.NUMBER &&
 
 				// AnnulledIf section
-				pred.Predict.AnnulledIf.Operator == types.LITERAL && len(pred.Predict.AnnulledIf.Literal.Operands) == 2 &&
-				pred.Predict.AnnulledIf.Literal.Operands[0].Type == types.COIN &&
-				pred.Predict.AnnulledIf.Literal.Operands[1].Type == types.NUMBER &&
+				pred.Predict.AnnulledIf.Operator == core.LITERAL && len(pred.Predict.AnnulledIf.Literal.Operands) == 2 &&
+				pred.Predict.AnnulledIf.Literal.Operands[0].Type == core.COIN &&
+				pred.Predict.AnnulledIf.Literal.Operands[1].Type == core.NUMBER &&
 
 				// Operators are opposite
 				operatorsAreOpposite(pred.Predict.Predict.Literal.Operator, pred.Predict.AnnulledIf.Literal.Operator)
 		},
-		types.PredictionTypeCoinWillRange: func(pred types.Prediction) bool {
+		core.PredictionTypeCoinWillRange: func(pred core.Prediction) bool {
 			return pred.PrePredict.Predict == nil && pred.PrePredict.AnnulledIf == nil &&
 				pred.PrePredict.WrongIf == nil && pred.Predict.AnnulledIf == nil && pred.Predict.WrongIf == nil &&
-				pred.Predict.Predict.Operator == types.LITERAL && len(pred.Predict.Predict.Literal.Operands) == 3 &&
+				pred.Predict.Predict.Operator == core.LITERAL && len(pred.Predict.Predict.Literal.Operands) == 3 &&
 				pred.Predict.Predict.Literal.Operator == "BETWEEN" &&
-				pred.Predict.Predict.Literal.Operands[0].Type == types.COIN &&
-				pred.Predict.Predict.Literal.Operands[1].Type == types.NUMBER &&
-				pred.Predict.Predict.Literal.Operands[2].Type == types.NUMBER
+				pred.Predict.Predict.Literal.Operands[0].Type == core.COIN &&
+				pred.Predict.Predict.Literal.Operands[1].Type == core.NUMBER &&
+				pred.Predict.Predict.Literal.Operands[2].Type == core.NUMBER
 		},
-		types.PredictionTypeCoinWillReachBeforeItReaches: func(pred types.Prediction) bool {
+		core.PredictionTypeCoinWillReachBeforeItReaches: func(pred core.Prediction) bool {
 			return pred.PrePredict.Predict == nil &&
 				pred.PrePredict.AnnulledIf == nil &&
 				pred.PrePredict.WrongIf == nil &&
 				pred.Predict.AnnulledIf == nil &&
 				pred.Predict.WrongIf == nil &&
-				pred.Predict.Predict.Operator == types.AND &&
+				pred.Predict.Predict.Operator == core.AND &&
 				len(pred.Predict.Predict.Operands) == 2 &&
-				pred.Predict.Predict.Operands[0].Operator == types.LITERAL &&
+				pred.Predict.Predict.Operands[0].Operator == core.LITERAL &&
 				len(pred.Predict.Predict.Operands[0].Literal.Operands) == 2 &&
-				pred.Predict.Predict.Operands[0].Literal.Operands[0].Type == types.COIN &&
-				pred.Predict.Predict.Operands[0].Literal.Operands[1].Type == types.NUMBER &&
-				pred.Predict.Predict.Operands[1].Operator == types.NOT &&
+				pred.Predict.Predict.Operands[0].Literal.Operands[0].Type == core.COIN &&
+				pred.Predict.Predict.Operands[0].Literal.Operands[1].Type == core.NUMBER &&
+				pred.Predict.Predict.Operands[1].Operator == core.NOT &&
 				len(pred.Predict.Predict.Operands[1].Operands) == 1 &&
-				pred.Predict.Predict.Operands[1].Operands[0].Operator == types.LITERAL &&
+				pred.Predict.Predict.Operands[1].Operands[0].Operator == core.LITERAL &&
 				len(pred.Predict.Predict.Operands[1].Operands[0].Literal.Operands) == 2 &&
-				pred.Predict.Predict.Operands[1].Operands[0].Literal.Operands[0].Type == types.COIN &&
-				pred.Predict.Predict.Operands[1].Operands[0].Literal.Operands[1].Type == types.NUMBER &&
+				pred.Predict.Predict.Operands[1].Operands[0].Literal.Operands[0].Type == core.COIN &&
+				pred.Predict.Predict.Operands[1].Operands[0].Literal.Operands[1].Type == core.NUMBER &&
 				pred.Predict.Predict.Operands[0].Literal.Operands[0] == pred.Predict.Predict.Operands[1].Operands[0].Literal.Operands[0] &&
 				pred.Predict.Predict.Operands[0].Literal.Operator != pred.Predict.Predict.Operands[1].Operands[0].Literal.Operator
 		},

--- a/compiler/prediction_type_test.go
+++ b/compiler/prediction_type_test.go
@@ -4,16 +4,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/marianogappa/predictions/core"
 	"github.com/marianogappa/predictions/metadatafetcher"
 	mfTypes "github.com/marianogappa/predictions/metadatafetcher/types"
-	"github.com/marianogappa/predictions/types"
 	"github.com/stretchr/testify/require"
 )
 
 func TestPredictionType(t *testing.T) {
 	tss := []struct {
 		name, pred string
-		expected   types.PredictionType
+		expected   core.PredictionType
 	}{
 		{
 			name: "Basic PREDICTION_TYPE_COIN_OPERATOR_FLOAT_DEADLINE",
@@ -31,7 +31,7 @@ func TestPredictionType(t *testing.T) {
 					"predict": "main"
 				}
 			}`,
-			expected: types.PredictionTypeCoinOperatorFloatDeadline,
+			expected: core.PredictionTypeCoinOperatorFloatDeadline,
 		},
 		{
 			name: "Basic PREDICTION_TYPE_COIN_WILL_REACH_INVALIDATED_IF_IT_REACHES",
@@ -55,7 +55,7 @@ func TestPredictionType(t *testing.T) {
 				  "ignoreUndecidedIfPredictIsDefined": true
 				}
 			  }`,
-			expected: types.PredictionTypeCoinWillReachInvalidatedIfItReaches,
+			expected: core.PredictionTypeCoinWillReachInvalidatedIfItReaches,
 		},
 		{
 			name: "Basic PREDICTION_TYPE_COIN_WILL_RANGE",
@@ -73,7 +73,7 @@ func TestPredictionType(t *testing.T) {
 					"predict": "main"
 				}
 			}`,
-			expected: types.PredictionTypeCoinWillRange,
+			expected: core.PredictionTypeCoinWillRange,
 		},
 		{
 			name: "Basic PREDICTION_TYPE_COIN_WILL_REACH_BEFORE_IT_REACHES",
@@ -96,7 +96,7 @@ func TestPredictionType(t *testing.T) {
 				  "predict": "a and (not b)"
 				}
 			  }`,
-			expected: types.PredictionTypeCoinWillReachBeforeItReaches,
+			expected: core.PredictionTypeCoinWillReachBeforeItReaches,
 		},
 		{
 			name: "Basic PREDICTION_TYPE_UNSUPPORTED",
@@ -216,7 +216,7 @@ func TestPredictionType(t *testing.T) {
 					"value": "ONGOING_PREDICTION"
 				}
 			}`,
-			expected: types.PredictionTypeUnsupported,
+			expected: core.PredictionTypeUnsupported,
 		},
 	}
 	for _, ts := range tss {
@@ -224,7 +224,7 @@ func TestPredictionType(t *testing.T) {
 			pc := NewPredictionCompiler(metadatafetcher.NewMetadataFetcher(), nil)
 			pc.metadataFetcher.Fetchers = []metadatafetcher.SpecificFetcher{
 				newTestMetadataFetcher(mfTypes.PostMetadata{
-					Author:        types.Account{Handle: "CryptoCapo_"},
+					Author:        core.Account{Handle: "CryptoCapo_"},
 					PostCreatedAt: tpToISO("2020-01-02 00:00:00"),
 				}, nil),
 			}

--- a/core/boolexpr.go
+++ b/core/boolexpr.go
@@ -1,4 +1,4 @@
-package types
+package core
 
 // BoolExpr represents a boolean expression in a prediction step.
 type BoolExpr struct {

--- a/core/boolexpr_test.go
+++ b/core/boolexpr_test.go
@@ -1,4 +1,4 @@
-package types
+package core
 
 import (
 	"reflect"

--- a/core/condition.go
+++ b/core/condition.go
@@ -1,4 +1,4 @@
-package types
+package core
 
 import (
 	"errors"

--- a/core/condition_state_value.go
+++ b/core/condition_state_value.go
@@ -1,4 +1,4 @@
-package types
+package core
 
 import (
 	"errors"

--- a/core/condition_state_value_test.go
+++ b/core/condition_state_value_test.go
@@ -1,4 +1,4 @@
-package types
+package core
 
 import "testing"
 

--- a/core/condition_test.go
+++ b/core/condition_test.go
@@ -1,4 +1,4 @@
-package types
+package core
 
 import (
 	"errors"

--- a/core/predict.go
+++ b/core/predict.go
@@ -1,4 +1,4 @@
-package types
+package core
 
 // Predict represents the main Prediction step.
 type Predict struct {

--- a/core/predict_test.go
+++ b/core/predict_test.go
@@ -1,4 +1,4 @@
-package types
+package core
 
 import (
 	"reflect"

--- a/core/prediction.go
+++ b/core/prediction.go
@@ -1,4 +1,4 @@
-package types
+package core
 
 // Prediction is the struct that represents a prediction after it being compiled.
 type Prediction struct {

--- a/core/prediction_types.go
+++ b/core/prediction_types.go
@@ -1,4 +1,4 @@
-package types
+package core
 
 import (
 	"math"

--- a/core/prepredict.go
+++ b/core/prepredict.go
@@ -1,4 +1,4 @@
-package types
+package core
 
 // PrePredict represents the initial, non-main prediction step.
 type PrePredict struct {

--- a/core/prepredict_test.go
+++ b/core/prepredict_test.go
@@ -1,4 +1,4 @@
-package types
+package core
 
 import (
 	"reflect"

--- a/core/types.go
+++ b/core/types.go
@@ -1,4 +1,4 @@
-package types
+package core
 
 import (
 	"errors"

--- a/daemon/pred_runner.go
+++ b/daemon/pred_runner.go
@@ -8,12 +8,12 @@ import (
 
 	"github.com/marianogappa/crypto-candles/candles"
 	"github.com/marianogappa/crypto-candles/candles/common"
-	"github.com/marianogappa/predictions/types"
+	"github.com/marianogappa/predictions/core"
 )
 
 // PredEvolver is the struct that evolves a prediction's state upon reading market data.
 type PredEvolver struct {
-	prediction *types.Prediction
+	prediction *core.Prediction
 	tickers    map[string]map[string]common.Iterator
 }
 
@@ -22,12 +22,12 @@ var (
 )
 
 // NewPredEvolver is the constructor for PredEvolver.
-func NewPredEvolver(prediction *types.Prediction, m candles.IMarket, nowTs int) (*PredEvolver, []error) {
+func NewPredEvolver(prediction *core.Prediction, m candles.IMarket, nowTs int) (*PredEvolver, []error) {
 	errs := []error{}
 	result := PredEvolver{prediction: prediction, tickers: make(map[string]map[string]common.Iterator)}
 
 	predStateValue := prediction.Evaluate()
-	if predStateValue != types.ONGOINGPREPREDICTION && predStateValue != types.ONGOINGPREDICTION {
+	if predStateValue != core.ONGOINGPREPREDICTION && predStateValue != core.ONGOINGPREDICTION {
 		errs = append(errs, errPredictionAtFinalStateAtCreation)
 		return nil, errs
 	}
@@ -79,7 +79,7 @@ func (r *PredEvolver) Run(once bool) []error {
 	return errs
 }
 
-func (r *PredEvolver) runCondition(cond *types.Condition) error {
+func (r *PredEvolver) runCondition(cond *core.Condition) error {
 	ticks := map[string]common.Tick{}
 	for key, ticker := range r.tickers[cond.Name] {
 		tick, err := ticker.NextTick()
@@ -92,8 +92,8 @@ func (r *PredEvolver) runCondition(cond *types.Condition) error {
 	return cond.Run(ticks)
 }
 
-func (r *PredEvolver) actionableNonStuckUndecidedConditions(stuckConditions map[string]struct{}) []*types.Condition {
-	conds := []*types.Condition{}
+func (r *PredEvolver) actionableNonStuckUndecidedConditions(stuckConditions map[string]struct{}) []*core.Condition {
+	conds := []*core.Condition{}
 	for _, cond := range r.prediction.ActionableUndecidedConditions() {
 		if _, ok := stuckConditions[cond.Name]; !ok {
 			conds = append(conds, cond)
@@ -102,7 +102,7 @@ func (r *PredEvolver) actionableNonStuckUndecidedConditions(stuckConditions map[
 	return conds
 }
 
-func calculateStartTs(c *types.Condition) (time.Time, bool) {
+func calculateStartTs(c *core.Condition) (time.Time, bool) {
 	startTs := c.FromTs
 	startFromNext := false
 

--- a/imagebuilder/build_image.go
+++ b/imagebuilder/build_image.go
@@ -16,8 +16,8 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/marianogappa/crypto-candles/candles"
+	"github.com/marianogappa/predictions/core"
 	"github.com/marianogappa/predictions/serializer"
-	"github.com/marianogappa/predictions/types"
 	"github.com/rs/zerolog/log"
 )
 
@@ -40,7 +40,7 @@ func NewPredictionImageBuilder(m candles.IMarket, files embed.FS, chromePath str
 // execute the Chrome binary. Prediction must be well-formed. Building candlestick chart depends on Internet access,
 // and the market communicates with an exchange's API that might be offline, might decide to 429, etc. A lot can
 // go wrong unfortunately.
-func (r PredictionImageBuilder) BuildImageBase64(prediction types.Prediction, account types.Account) (string, error) {
+func (r PredictionImageBuilder) BuildImageBase64(prediction core.Prediction, account core.Account) (string, error) {
 	url, err := r.BuildImage(prediction, account)
 	if err != nil {
 		return "", err
@@ -76,7 +76,7 @@ func (r PredictionImageBuilder) BuildImageBase64(prediction types.Prediction, ac
 // execute the Chrome binary. Prediction must be well-formed. Building candlestick chart depends on Internet access,
 // and the market communicates with an exchange's API that might be offline, might decide to 429, etc. A lot can
 // go wrong unfortunately.
-func (r PredictionImageBuilder) BuildImage(prediction types.Prediction, account types.Account) (string, error) {
+func (r PredictionImageBuilder) BuildImage(prediction core.Prediction, account core.Account) (string, error) {
 	if r.chromePath == "" {
 		return "", errors.New("daemon.buildImageAction: PREDICTIONS_CHROME_PATH env not set")
 	}

--- a/metadatafetcher/metadata_fetcher.go
+++ b/metadatafetcher/metadata_fetcher.go
@@ -3,7 +3,7 @@ package metadatafetcher
 import (
 	"net/url"
 
-	"github.com/marianogappa/predictions/metadatafetcher/types"
+	core "github.com/marianogappa/predictions/metadatafetcher/types"
 	"github.com/marianogappa/predictions/metadatafetcher/youtube"
 
 	"github.com/marianogappa/predictions/metadatafetcher/twitter"
@@ -12,7 +12,7 @@ import (
 // SpecificFetcher is the interface for a concrete fetcher, e.g. youtube.Fetcher, twitter.Fetcher.
 type SpecificFetcher interface {
 	IsCorrectFetcher(url *url.URL) bool
-	Fetch(url *url.URL) (types.PostMetadata, error)
+	Fetch(url *url.URL) (core.PostMetadata, error)
 }
 
 // MetadataFetcher is the main struct for the social media account metadata fetcher.
@@ -27,10 +27,10 @@ func NewMetadataFetcher() *MetadataFetcher {
 
 // Fetch takes a URL string, loops through the available fetchers looking for the correct one, and then requests
 // metadata for that URL using the specific fetcher.
-func (f MetadataFetcher) Fetch(rawURL string) (types.PostMetadata, error) {
+func (f MetadataFetcher) Fetch(rawURL string) (core.PostMetadata, error) {
 	url, err := url.Parse(rawURL)
 	if err != nil {
-		return types.PostMetadata{}, err
+		return core.PostMetadata{}, err
 	}
 
 	for _, fetcher := range f.Fetchers {
@@ -43,5 +43,5 @@ func (f MetadataFetcher) Fetch(rawURL string) (types.PostMetadata, error) {
 		}
 		return m, nil
 	}
-	return types.PostMetadata{}, types.ErrNoMetadataFound
+	return core.PostMetadata{}, core.ErrNoMetadataFound
 }

--- a/metadatafetcher/metadata_fetcher_test.go
+++ b/metadatafetcher/metadata_fetcher_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/marianogappa/predictions/metadatafetcher/twitter"
-	"github.com/marianogappa/predictions/metadatafetcher/types"
+	core "github.com/marianogappa/predictions/metadatafetcher/types"
 	"github.com/marianogappa/predictions/metadatafetcher/youtube"
 )
 
@@ -19,7 +19,7 @@ func TestMetadataFetcherFetchInvalidURL(t *testing.T) {
 
 func TestMetadataFetcherFetchNoValidFetchers(t *testing.T) {
 	_, err := NewMetadataFetcher().Fetch("https://unsupportedsite.com?v=123456543")
-	if err != types.ErrNoMetadataFound {
+	if err != core.ErrNoMetadataFound {
 		t.Errorf("should have failed with no metadata found")
 	}
 }

--- a/metadatafetcher/twitter/api.go
+++ b/metadatafetcher/twitter/api.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/dghubble/oauth1"
 	"github.com/drswork/go-twitter/twitter"
+	"github.com/marianogappa/predictions/core"
 	"github.com/marianogappa/predictions/request"
-	"github.com/marianogappa/predictions/types"
 )
 
 var (
@@ -90,7 +90,7 @@ type responseIncludesUsers struct {
 	Name          string                             `json:"name"`
 	Username      string                             `json:"username"`
 	Verified      bool                               `json:"verified"`
-	CreatedAt     types.ISO8601                      `json:"created_at"`
+	CreatedAt     core.ISO8601                       `json:"created_at"`
 	ProfileImgURL string                             `json:"profile_image_url"`
 	PublicMetrics responseIncludesUsersPublicMetrics `json:"public_metrics"`
 }
@@ -109,14 +109,14 @@ func responseToTweet(r response) (Tweet, error) {
 	if len(r.Errors) > 0 {
 		return Tweet{}, fmt.Errorf("there are errors in Twitter's API response: %v", string(r.Errors))
 	}
-	tweetCreatedAt, err := types.ISO8601(r.Data.CreatedAt).Time()
+	tweetCreatedAt, err := core.ISO8601(r.Data.CreatedAt).Time()
 	if err != nil {
 		return Tweet{}, fmt.Errorf("while parsing r.Data.CreatedAt (%v) as ISO8601: %w", r.Data.CreatedAt, err)
 	}
 	if len(r.Includes.Users) < 1 {
 		return Tweet{}, fmt.Errorf("expecting len(r.Includes.Users) to be >= 1, but was %v", len(r.Includes.Users))
 	}
-	userCreatedAt, err := types.ISO8601(r.Includes.Users[0].CreatedAt).Time()
+	userCreatedAt, err := core.ISO8601(r.Includes.Users[0].CreatedAt).Time()
 	if err != nil {
 		return Tweet{}, fmt.Errorf("while parsing r.Includes.Users[0].CreatedAt (%v) as ISO8601: %w", r.Includes.Users[0].CreatedAt, err)
 	}

--- a/metadatafetcher/twitter/fetcher.go
+++ b/metadatafetcher/twitter/fetcher.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/marianogappa/predictions/core"
 	"github.com/marianogappa/predictions/metadatafetcher/types"
-	coreTypes "github.com/marianogappa/predictions/types"
 )
 
 // MetadataFetcher is the main struct for fetching metadata from Twitter.
@@ -49,7 +49,7 @@ func (f MetadataFetcher) Fetch(u *url.URL) (types.PostMetadata, error) {
 	}
 
 	return types.PostMetadata{
-		Author: coreTypes.Account{
+		Author: core.Account{
 			URL:           userURL,
 			AccountType:   "TWITTER",
 			FollowerCount: tweet.FollowersCount,
@@ -61,7 +61,7 @@ func (f MetadataFetcher) Fetch(u *url.URL) (types.PostMetadata, error) {
 		},
 		PostTitle:     tweet.TweetText,
 		PostText:      tweet.TweetText,
-		PostCreatedAt: coreTypes.ISO8601(tweet.TweetCreatedAt.Format(time.RFC3339)), // TODO
+		PostCreatedAt: core.ISO8601(tweet.TweetCreatedAt.Format(time.RFC3339)), // TODO
 		PostType:      types.TWITTER,
 	}, nil
 }

--- a/metadatafetcher/twitter/twitter_test.go
+++ b/metadatafetcher/twitter/twitter_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/marianogappa/predictions/core"
 	mfTypes "github.com/marianogappa/predictions/metadatafetcher/types"
-	"github.com/marianogappa/predictions/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -60,7 +60,7 @@ func TestTwitterHappyCase(t *testing.T) {
 	}
 
 	expected := mfTypes.PostMetadata{
-		Author: types.Account{
+		Author: core.Account{
 			URL:           mURL("https://twitter.com/rovercrc"),
 			AccountType:   "TWITTER",
 			Handle:        "rovercrc",
@@ -73,7 +73,7 @@ func TestTwitterHappyCase(t *testing.T) {
 		},
 		PostTitle:     "Where are the bears now? 🐻🔫",
 		PostText:      "Where are the bears now? 🐻🔫",
-		PostCreatedAt: types.ISO8601("2022-03-24T15:26:16Z"),
+		PostCreatedAt: core.ISO8601("2022-03-24T15:26:16Z"),
 		PostType:      mfTypes.TWITTER,
 	}
 

--- a/metadatafetcher/types/types.go
+++ b/metadatafetcher/types/types.go
@@ -3,7 +3,7 @@ package types
 import (
 	"errors"
 
-	"github.com/marianogappa/predictions/types"
+	"github.com/marianogappa/predictions/core"
 )
 
 // PostType is the website used for the post, e.g. Twitter, Youtube.
@@ -25,10 +25,10 @@ var (
 
 // PostMetadata contains the metadata gathered about a post by querying a website's API about it.
 type PostMetadata struct {
-	Author             types.Account
+	Author             core.Account
 	PostTitle          string
 	PostText           string
-	PostCreatedAt      types.ISO8601
+	PostCreatedAt      core.ISO8601
 	PostType           PostType
 	ThumbnailImgSmall  string
 	ThumbnailImgMedium string

--- a/metadatafetcher/youtube/api.go
+++ b/metadatafetcher/youtube/api.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/marianogappa/predictions/core"
 	"github.com/marianogappa/predictions/request"
-	"github.com/marianogappa/predictions/types"
 )
 
 // Youtube is the main struct for the Youtube component that interacts with Youtube via the Youtube API.
@@ -32,7 +32,7 @@ type Video struct {
 	VideoTitle           string
 	VideoDescription     string
 	VideoID              string
-	PublishedAt          types.ISO8601
+	PublishedAt          core.ISO8601
 	ChannelID            string
 	ChannelTitle         string
 	ThumbnailDefaultURL  string
@@ -58,7 +58,7 @@ type responseSnippetThumbnails struct {
 }
 
 type responseSnippet struct {
-	PublishedAt  types.ISO8601             `json:"publishedAt"`
+	PublishedAt  core.ISO8601              `json:"publishedAt"`
 	ChannelID    string                    `json:"channelId"`
 	Title        string                    `json:"title"`
 	Description  string                    `json:"description"`
@@ -122,7 +122,7 @@ func (t Youtube) getVideoByID(id string) (Video, error) {
 type Channel struct {
 	ID                  string
 	URL                 string
-	PublishedAt         types.ISO8601
+	PublishedAt         core.ISO8601
 	Title               string
 	Description         string
 	ThumbnailDefaultURL string
@@ -171,7 +171,7 @@ type channelsResponseStatistics struct {
 type channelsResponseSnippet struct {
 	Title       string                            `json:"title"`
 	Description string                            `json:"description"`
-	PublishedAt types.ISO8601                     `json:"publishedAt"`
+	PublishedAt core.ISO8601                      `json:"publishedAt"`
 	Thumbnails  channelsResponseSnippetThumbnails `json:"thumbnails"`
 }
 

--- a/metadatafetcher/youtube/fetcher.go
+++ b/metadatafetcher/youtube/fetcher.go
@@ -6,8 +6,8 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/marianogappa/predictions/core"
 	mfTypes "github.com/marianogappa/predictions/metadatafetcher/types"
-	"github.com/marianogappa/predictions/types"
 )
 
 // MetadataFetcher is the main struct for fetching metadata from Youtube.
@@ -76,7 +76,7 @@ func (f MetadataFetcher) Fetch(fetchURL *url.URL) (mfTypes.PostMetadata, error) 
 	}
 
 	return mfTypes.PostMetadata{
-		Author: types.Account{
+		Author: core.Account{
 			URL:           chURL,
 			AccountType:   "YOUTUBE",
 			FollowerCount: channel.SubscriberCount,

--- a/metadatafetcher/youtube/youtube_test.go
+++ b/metadatafetcher/youtube/youtube_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/marianogappa/predictions/core"
 	mfTypes "github.com/marianogappa/predictions/metadatafetcher/types"
-	"github.com/marianogappa/predictions/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -157,7 +157,7 @@ func TestYoutubeHappyCase(t *testing.T) {
 	}
 
 	expected := mfTypes.PostMetadata{
-		Author: types.Account{
+		Author: core.Account{
 			URL:           mURL("https://youtube.com/channel/UCy6kyFxaMqGtpE3pQTflK8A"),
 			AccountType:   "YOUTUBE",
 			FollowerCount: 2290000,
@@ -174,7 +174,7 @@ func TestYoutubeHappyCase(t *testing.T) {
 		ThumbnailImgMedium: "https://i.ytimg.com/vi/ozgGPWnVLkY/mqdefault.jpg",
 		PostTitle:          "Dozens of diplomats walk out during Russian foreign minister's UN speech",
 		PostText:           "Dozens of diplomats walked out of a speech by the Russian foreign minister",
-		PostCreatedAt:      types.ISO8601("2022-03-01T16:28:50Z"),
+		PostCreatedAt:      core.ISO8601("2022-03-01T16:28:50Z"),
 		PostType:           mfTypes.YOUTUBE,
 	}
 

--- a/printer/bool_expr.go
+++ b/printer/bool_expr.go
@@ -4,12 +4,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/marianogappa/predictions/core"
 	"github.com/rs/zerolog/log"
-
-	"github.com/marianogappa/predictions/types"
 )
 
-func printBoolExpr(e *types.BoolExpr, nestLevel int) string {
+func printBoolExpr(e *core.BoolExpr, nestLevel int) string {
 	if e == nil {
 		return ""
 	}
@@ -27,7 +26,7 @@ func printBoolExpr(e *types.BoolExpr, nestLevel int) string {
 		operands = append(operands, s)
 	}
 	switch e.Operator {
-	case types.AND, types.OR:
+	case core.AND, core.OR:
 		if len(operands) == 0 {
 			return ""
 		}
@@ -36,11 +35,11 @@ func printBoolExpr(e *types.BoolExpr, nestLevel int) string {
 		}
 
 		connector := " and "
-		if e.Operator == types.OR {
+		if e.Operator == core.OR {
 			connector = " or "
 		}
 		return fmt.Sprintf("%v%v%v", prefix, strings.Join(operands, connector), postfix)
-	case types.NOT:
+	case core.NOT:
 		return fmt.Sprintf("%vNOT %v%v", prefix, operands[0], postfix)
 	default:
 		// TODO: this if is due to a bug that needs to be fixed

--- a/printer/condition.go
+++ b/printer/condition.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/marianogappa/predictions/types"
+	"github.com/marianogappa/predictions/core"
 )
 
-func printCondition(c types.Condition, ignoreFromTs bool) string {
+func printCondition(c core.Condition, ignoreFromTs bool) string {
 	fromTs := formatTs(c.FromTs)
 	toTs := formatTs(c.ToTs)
 
@@ -159,11 +159,11 @@ var (
 	}
 )
 
-func parseOperand(op types.Operand, useDollarSign bool) (string, bool) {
-	if op.Type == types.NUMBER {
+func parseOperand(op core.Operand, useDollarSign bool) (string, bool) {
+	if op.Type == core.NUMBER {
 		return parseNumber(op.Number, useDollarSign), useDollarSign
 	}
-	if op.Type == types.MARKETCAP {
+	if op.Type == core.MARKETCAP {
 		return fmt.Sprintf("%v's MarketCap", op.BaseAsset), false
 	}
 	suffix := ""
@@ -182,12 +182,12 @@ func parseOperand(op types.Operand, useDollarSign bool) (string, bool) {
 	return parsedMarket, quoteAssetIsStableCoin
 }
 
-func legacyParseOperand(op types.Operand) string {
+func legacyParseOperand(op core.Operand) string {
 	s, _ := parseOperand(op, false)
 	return s
 }
 
-func parseNumber(num types.JSONFloat64, useDollarSign bool) string {
+func parseNumber(num core.JSONFloat64, useDollarSign bool) string {
 	dollarSign := ""
 	if useDollarSign {
 		dollarSign = "$"

--- a/printer/predict.go
+++ b/printer/predict.go
@@ -3,10 +3,10 @@ package printer
 import (
 	"fmt"
 
-	"github.com/marianogappa/predictions/types"
+	"github.com/marianogappa/predictions/core"
 )
 
-func printPredict(p types.Predict) string {
+func printPredict(p core.Predict) string {
 	if p.WrongIf != nil && p.AnnulledIf != nil {
 		return fmt.Sprintf("%v, being wrong if %v, unless %v in which case all bets are off", printBoolExpr(&p.Predict, 0), printBoolExpr(p.WrongIf, 0), printBoolExpr(p.AnnulledIf, 0))
 	}
@@ -19,7 +19,7 @@ func printPredict(p types.Predict) string {
 	return printBoolExpr(&p.Predict, 0)
 }
 
-func printPrePredict(p types.PrePredict) string {
+func printPrePredict(p core.PrePredict) string {
 	if p.Predict == nil {
 		return ""
 	}

--- a/printer/prediction_pretty_printer.go
+++ b/printer/prediction_pretty_printer.go
@@ -4,17 +4,17 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/marianogappa/predictions/types"
+	"github.com/marianogappa/predictions/core"
 )
 
 // PredictionPrettyPrinter builds a human-readable description of a prediction, e.g.:
 // "Bitcoin will be below $17k in 2 weeks"
 type PredictionPrettyPrinter struct {
-	prediction types.Prediction
+	prediction core.Prediction
 }
 
 // NewPredictionPrettyPrinter constructs a PredictionPrettyPrinter.
-func NewPredictionPrettyPrinter(p types.Prediction) PredictionPrettyPrinter {
+func NewPredictionPrettyPrinter(p core.Prediction) PredictionPrettyPrinter {
 	return PredictionPrettyPrinter{prediction: p}
 }
 
@@ -22,14 +22,14 @@ func NewPredictionPrettyPrinter(p types.Prediction) PredictionPrettyPrinter {
 // "Bitcoin will be below $17k in 2 weeks"
 func (p PredictionPrettyPrinter) String() string {
 	switch p.prediction.Type {
-	case types.PredictionTypeCoinOperatorFloatDeadline:
+	case core.PredictionTypeCoinOperatorFloatDeadline:
 		// TODO: this if is necessary because there's a bug where some predictions are miscategorised
 		if p.prediction.Predict.Predict.Literal != nil && len(p.prediction.Predict.Predict.Literal.Operands) == 2 {
 			return p.predictionTypeCoinOperatorFloatDeadline()
 		}
-	// case types.PREDICTION_TYPE_COIN_WILL_RANGE:
+	// case core.PREDICTION_TYPE_COIN_WILL_RANGE:
 	// 	p.predictionTypeCoinWillRange()
-	case types.PredictionTypeCoinWillReachBeforeItReaches:
+	case core.PredictionTypeCoinWillReachBeforeItReaches:
 		p.predictionTypeCoinWillReachBeforeItReaches()
 	}
 

--- a/serializer/serializer_summary.go
+++ b/serializer/serializer_summary.go
@@ -6,26 +6,26 @@ import (
 
 	"github.com/marianogappa/crypto-candles/candles/common"
 	"github.com/marianogappa/predictions/compiler"
-	"github.com/marianogappa/predictions/types"
+	"github.com/marianogappa/predictions/core"
 )
 
 // BuildPredictionMarketSummary builds a PredictionSummary from a prediction. It uses a market to get candlesticks.
-func (s PredictionSerializer) BuildPredictionMarketSummary(p types.Prediction) (compiler.PredictionSummary, error) {
+func (s PredictionSerializer) BuildPredictionMarketSummary(p core.Prediction) (compiler.PredictionSummary, error) {
 	switch p.Type {
-	case types.PredictionTypeCoinOperatorFloatDeadline:
+	case core.PredictionTypeCoinOperatorFloatDeadline:
 		return s.predictionTypeCoinOperatorFloatDeadline(p)
-	case types.PredictionTypeCoinWillReachInvalidatedIfItReaches:
+	case core.PredictionTypeCoinWillReachInvalidatedIfItReaches:
 		return s.predictionTypeCoinWillReachInvalidatedIfItReaches(p)
-	case types.PredictionTypeCoinWillRange:
+	case core.PredictionTypeCoinWillRange:
 		return s.predictionTypeCoinWillRange(p)
-	case types.PredictionTypeCoinWillReachBeforeItReaches:
+	case core.PredictionTypeCoinWillReachBeforeItReaches:
 		return s.predictionTypeCoinWillReachBeforeItReaches(p)
 	}
 	return compiler.PredictionSummary{}, nil
 }
 
-func (s PredictionSerializer) predictionTypeCoinOperatorFloatDeadline(p types.Prediction) (compiler.PredictionSummary, error) {
-	typedPred := types.PredictionTypeCoinOperatorFloatDeadlineWrapper{P: p}
+func (s PredictionSerializer) predictionTypeCoinOperatorFloatDeadline(p core.Prediction) (compiler.PredictionSummary, error) {
+	typedPred := core.PredictionTypeCoinOperatorFloatDeadlineWrapper{P: p}
 
 	chartParams, err := getCandlestickChartParams(p)
 	if err != nil {
@@ -52,16 +52,16 @@ func (s PredictionSerializer) predictionTypeCoinOperatorFloatDeadline(p types.Pr
 		Operator:                                typedPred.Operator(),
 		Goal:                                    typedPred.Goal(),
 		GoalWithError:                           typedPred.GoalWithError(),
-		ErrorMarginRatio:                        types.JSONFloat64(typedPred.ErrorMarginRatio()),
-		Deadline:                                types.ISO8601(typedPred.Deadline().Format(time.RFC3339)),
-		EndedAt:                                 types.ISO8601(typedPred.EndTime().Format(time.RFC3339)),
-		EndedAtTruncatedDueToResultInvalidation: types.ISO8601(typedPred.EndTimeTruncatedDueToResultInvalidation(candlesticks[opStr]).Format(time.RFC3339)),
+		ErrorMarginRatio:                        core.JSONFloat64(typedPred.ErrorMarginRatio()),
+		Deadline:                                core.ISO8601(typedPred.Deadline().Format(time.RFC3339)),
+		EndedAt:                                 core.ISO8601(typedPred.EndTime().Format(time.RFC3339)),
+		EndedAtTruncatedDueToResultInvalidation: core.ISO8601(typedPred.EndTimeTruncatedDueToResultInvalidation(candlesticks[opStr]).Format(time.RFC3339)),
 		Coin:                                    opStr,
 	}, nil
 }
 
-func (s PredictionSerializer) predictionTypeCoinWillReachInvalidatedIfItReaches(p types.Prediction) (compiler.PredictionSummary, error) {
-	typedPred := types.PredictionTypeCoinWillReachInvalidatedIfItReachesWrapper{P: p}
+func (s PredictionSerializer) predictionTypeCoinWillReachInvalidatedIfItReaches(p core.Prediction) (compiler.PredictionSummary, error) {
+	typedPred := core.PredictionTypeCoinWillReachInvalidatedIfItReachesWrapper{P: p}
 
 	chartParams, err := getCandlestickChartParams(p)
 	if err != nil {
@@ -89,16 +89,16 @@ func (s PredictionSerializer) predictionTypeCoinWillReachInvalidatedIfItReaches(
 		Goal:                                    typedPred.Goal(),
 		GoalWithError:                           typedPred.GoalWithError(),
 		InvalidatedIfItReaches:                  typedPred.InvalidatedIfItReaches(),
-		ErrorMarginRatio:                        types.JSONFloat64(typedPred.ErrorMarginRatio()),
-		Deadline:                                types.ISO8601(typedPred.Deadline().Format(time.RFC3339)),
-		EndedAt:                                 types.ISO8601(typedPred.EndTime().Format(time.RFC3339)),
-		EndedAtTruncatedDueToResultInvalidation: types.ISO8601(typedPred.EndTimeTruncatedDueToResultInvalidation(candlesticks[opStr]).Format(time.RFC3339)),
+		ErrorMarginRatio:                        core.JSONFloat64(typedPred.ErrorMarginRatio()),
+		Deadline:                                core.ISO8601(typedPred.Deadline().Format(time.RFC3339)),
+		EndedAt:                                 core.ISO8601(typedPred.EndTime().Format(time.RFC3339)),
+		EndedAtTruncatedDueToResultInvalidation: core.ISO8601(typedPred.EndTimeTruncatedDueToResultInvalidation(candlesticks[opStr]).Format(time.RFC3339)),
 		Coin:                                    opStr,
 	}, nil
 }
 
-func (s PredictionSerializer) predictionTypeCoinWillRange(p types.Prediction) (compiler.PredictionSummary, error) {
-	typedPred := types.PredictionTypeCoinWillRangeWrapper{P: p}
+func (s PredictionSerializer) predictionTypeCoinWillRange(p core.Prediction) (compiler.PredictionSummary, error) {
+	typedPred := core.PredictionTypeCoinWillRangeWrapper{P: p}
 	coin := typedPred.Coin()
 
 	chartParams, err := getCandlestickChartParams(p)
@@ -123,9 +123,9 @@ func (s PredictionSerializer) predictionTypeCoinWillRange(p types.Prediction) (c
 	return compiler.PredictionSummary{
 		PredictionType:     p.Type.String(),
 		CandlestickMap:     candlesticks,
-		Deadline:           types.ISO8601(typedPred.Deadline().Format(time.RFC3339)),
-		EndedAt:            types.ISO8601(typedPred.EndTime().Format(time.RFC3339)),
-		ErrorMarginRatio:   types.JSONFloat64(typedPred.ErrorMarginRatio()),
+		Deadline:           core.ISO8601(typedPred.Deadline().Format(time.RFC3339)),
+		EndedAt:            core.ISO8601(typedPred.EndTime().Format(time.RFC3339)),
+		ErrorMarginRatio:   core.JSONFloat64(typedPred.ErrorMarginRatio()),
 		RangeLow:           typedPred.RangeLow(),
 		RangeLowWithError:  typedPred.RangeLowWithError(),
 		RangeHigh:          typedPred.RangeHigh(),
@@ -134,8 +134,8 @@ func (s PredictionSerializer) predictionTypeCoinWillRange(p types.Prediction) (c
 	}, nil
 }
 
-func (s PredictionSerializer) predictionTypeCoinWillReachBeforeItReaches(p types.Prediction) (compiler.PredictionSummary, error) {
-	typedPred := types.PredictionTypeCoinWillReachBeforeItReachesWrapper{P: p}
+func (s PredictionSerializer) predictionTypeCoinWillReachBeforeItReaches(p core.Prediction) (compiler.PredictionSummary, error) {
+	typedPred := core.PredictionTypeCoinWillReachBeforeItReachesWrapper{P: p}
 	coin := typedPred.Coin()
 
 	chartParams, err := getCandlestickChartParams(p)
@@ -160,9 +160,9 @@ func (s PredictionSerializer) predictionTypeCoinWillReachBeforeItReaches(p types
 	return compiler.PredictionSummary{
 		PredictionType:           p.Type.String(),
 		CandlestickMap:           candlesticks,
-		Deadline:                 types.ISO8601(typedPred.Deadline().Format(time.RFC3339)),
-		EndedAt:                  types.ISO8601(typedPred.EndTime().Format(time.RFC3339)),
-		ErrorMarginRatio:         types.JSONFloat64(typedPred.ErrorMarginRatio()),
+		Deadline:                 core.ISO8601(typedPred.Deadline().Format(time.RFC3339)),
+		EndedAt:                  core.ISO8601(typedPred.EndTime().Format(time.RFC3339)),
+		ErrorMarginRatio:         core.JSONFloat64(typedPred.ErrorMarginRatio()),
 		WillReach:                typedPred.WillReach(),
 		WillReachWithError:       typedPred.WillReachWithError(),
 		BeforeItReaches:          typedPred.BeforeItReaches(),
@@ -181,7 +181,7 @@ func (p candlestickChartParams) candlestickIntervalMinutes() int {
 	return int(p.candlestickInterval / time.Minute)
 }
 
-func getCandlestickChartParams(p types.Prediction) (candlestickChartParams, error) {
+func getCandlestickChartParams(p core.Prediction) (candlestickChartParams, error) {
 	startTime, err := p.PostedAt.Time()
 	if err != nil {
 		return candlestickChartParams{}, err
@@ -189,7 +189,7 @@ func getCandlestickChartParams(p types.Prediction) (candlestickChartParams, erro
 
 	// Compute endTime as the earliest of time.Now(), the lastTs when prediction finished & the prediction's deadline
 	endTime := time.Now().UTC()
-	if p.State.LastTs != 0 && p.State.Status == types.FINISHED {
+	if p.State.LastTs != 0 && p.State.Status == core.FINISHED {
 		lastTime := time.Unix(int64(p.State.LastTs), 0)
 
 		if lastTime.Before(endTime) {

--- a/serializer/serializer_test.go
+++ b/serializer/serializer_test.go
@@ -6,20 +6,20 @@ import (
 	"testing"
 	"time"
 
-	"github.com/marianogappa/predictions/types"
+	"github.com/marianogappa/predictions/core"
 	"github.com/stretchr/testify/require"
 )
 
 func TestSerialize(t *testing.T) {
 	tss := []struct {
 		name     string
-		pred     types.Prediction
+		pred     core.Prediction
 		err      error
 		expected string
 	}{
 		{
 			name: "Happy Case",
-			pred: types.Prediction{
+			pred: core.Prediction{
 				Version:    "1.0.0",
 				CreatedAt:  tpToISO("2020-01-03 00:00:00"),
 				Reporter:   "admin",
@@ -27,13 +27,13 @@ func TestSerialize(t *testing.T) {
 				PostText:   "",
 				PostedAt:   tpToISO("2020-01-02 00:00:00"),
 				PostURL:    "https://twitter.com/CryptoCapo_/status/1491357566974054400",
-				Given: map[string]*types.Condition{
+				Given: map[string]*core.Condition{
 					"main": {
 						Name:     "main",
 						Operator: "<=",
-						Operands: []types.Operand{
-							{Type: types.COIN, Provider: "BINANCE", BaseAsset: "ADA", QuoteAsset: "USDT", Str: "COIN:BINANCE:ADA-USDT"},
-							{Type: types.NUMBER, Number: types.JSONFloat64(0.845), Str: "0.845"},
+						Operands: []core.Operand{
+							{Type: core.COIN, Provider: "BINANCE", BaseAsset: "ADA", QuoteAsset: "USDT", Str: "COIN:BINANCE:ADA-USDT"},
+							{Type: core.NUMBER, Number: core.JSONFloat64(0.845), Str: "0.845"},
 						},
 						FromTs:           int(tp("2020-01-02 00:00:00").Unix()),
 						ToTs:             int(tp("2020-01-04 00:00:00").Unix()),
@@ -41,16 +41,16 @@ func TestSerialize(t *testing.T) {
 						ErrorMarginRatio: 0.03,
 					},
 				},
-				PrePredict: types.PrePredict{
-					Predict: &types.BoolExpr{
-						Operator: types.LITERAL,
+				PrePredict: core.PrePredict{
+					Predict: &core.BoolExpr{
+						Operator: core.LITERAL,
 						Operands: nil,
-						Literal: &types.Condition{
+						Literal: &core.Condition{
 							Name:     "main",
 							Operator: "<=",
-							Operands: []types.Operand{
-								{Type: types.COIN, Provider: "BINANCE", BaseAsset: "ADA", QuoteAsset: "USDT", Str: "COIN:BINANCE:ADA-USDT"},
-								{Type: types.NUMBER, Number: types.JSONFloat64(0.845), Str: "0.845"},
+							Operands: []core.Operand{
+								{Type: core.COIN, Provider: "BINANCE", BaseAsset: "ADA", QuoteAsset: "USDT", Str: "COIN:BINANCE:ADA-USDT"},
+								{Type: core.NUMBER, Number: core.JSONFloat64(0.845), Str: "0.845"},
 							},
 							FromTs:           int(tp("2020-01-02 00:00:00").Unix()),
 							ToTs:             int(tp("2020-01-04 00:00:00").Unix()),
@@ -61,16 +61,16 @@ func TestSerialize(t *testing.T) {
 					AnnulledIfPredictIsFalse:          true,
 					IgnoreUndecidedIfPredictIsDefined: true,
 				},
-				Predict: types.Predict{
-					Predict: types.BoolExpr{
-						Operator: types.LITERAL,
+				Predict: core.Predict{
+					Predict: core.BoolExpr{
+						Operator: core.LITERAL,
 						Operands: nil,
-						Literal: &types.Condition{
+						Literal: &core.Condition{
 							Name:     "main",
 							Operator: "<=",
-							Operands: []types.Operand{
-								{Type: types.COIN, Provider: "BINANCE", BaseAsset: "ADA", QuoteAsset: "USDT", Str: "COIN:BINANCE:ADA-USDT"},
-								{Type: types.NUMBER, Number: types.JSONFloat64(0.845), Str: "0.845"},
+							Operands: []core.Operand{
+								{Type: core.COIN, Provider: "BINANCE", BaseAsset: "ADA", QuoteAsset: "USDT", Str: "COIN:BINANCE:ADA-USDT"},
+								{Type: core.NUMBER, Number: core.JSONFloat64(0.845), Str: "0.845"},
 							},
 							FromTs:           int(tp("2020-01-02 00:00:00").Unix()),
 							ToTs:             int(tp("2020-01-04 00:00:00").Unix()),
@@ -80,7 +80,7 @@ func TestSerialize(t *testing.T) {
 					},
 					IgnoreUndecidedIfPredictIsDefined: true,
 				},
-				Type: types.PredictionTypeCoinOperatorFloatDeadline,
+				Type: core.PredictionTypeCoinOperatorFloatDeadline,
 			},
 			err: nil,
 			expected: `{
@@ -162,9 +162,9 @@ func TestSerialize(t *testing.T) {
 	}
 }
 
-func tpToISO(s string) types.ISO8601 {
+func tpToISO(s string) core.ISO8601 {
 	t, _ := time.Parse("2006-01-02 15:04:05", s)
-	return types.ISO8601(t.Format(time.RFC3339))
+	return core.ISO8601(t.Format(time.RFC3339))
 }
 
 func tp(s string) time.Time {

--- a/statestorage/pred_scanner.go
+++ b/statestorage/pred_scanner.go
@@ -1,17 +1,15 @@
 package statestorage
 
-import (
-	"github.com/marianogappa/predictions/types"
-)
+import "github.com/marianogappa/predictions/core"
 
 // PredictionScanner is a storage-layer Prediction iterator that follows the Scanner interface.
 type PredictionScanner struct {
 	Error error
 
 	store       StateStorage
-	predictions []types.Prediction
+	predictions []core.Prediction
 	lastUUID    string
-	filters     types.APIFilters
+	filters     core.APIFilters
 	limit       int
 }
 
@@ -28,17 +26,17 @@ func NewAllPredictionsScanner(store StateStorage) *PredictionScanner {
 }
 
 var (
-	filterEvolvable = types.APIFilters{
+	filterEvolvable = core.APIFilters{
 		PredictionStateValues: []string{
-			types.ONGOINGPREPREDICTION.String(),
-			types.ONGOINGPREDICTION.String(),
+			core.ONGOINGPREPREDICTION.String(),
+			core.ONGOINGPREDICTION.String(),
 		},
 		Paused:               pBool(false),
 		Deleted:              pBool(false),
 		IncludeUIUnsupported: true,
 	}
 
-	filterAll = types.APIFilters{
+	filterAll = core.APIFilters{
 		Paused:               nil,
 		Deleted:              nil,
 		Hidden:               nil,
@@ -46,14 +44,14 @@ var (
 	}
 )
 
-func newPredictionScanner(store StateStorage, filters types.APIFilters, batchSize int) *PredictionScanner {
+func newPredictionScanner(store StateStorage, filters core.APIFilters, batchSize int) *PredictionScanner {
 	if batchSize == 0 {
 		batchSize = 100
 	}
 	return &PredictionScanner{store: store, filters: filters, limit: batchSize}
 }
 
-func (it *PredictionScanner) query() ([]types.Prediction, error) {
+func (it *PredictionScanner) query() ([]core.Prediction, error) {
 	filters := it.filters
 
 	// Note that the iterator strategy is WHERE uuid > lastUUID.
@@ -63,7 +61,7 @@ func (it *PredictionScanner) query() ([]types.Prediction, error) {
 
 	preds, err := it.store.GetPredictions(
 		filters,
-		[]string{types.PredictionsUUIDAsc.String()},
+		[]string{core.PredictionsUUIDAsc.String()},
 		it.limit, 0,
 	)
 	if err != nil {
@@ -76,16 +74,16 @@ func (it *PredictionScanner) query() ([]types.Prediction, error) {
 	return preds, nil
 }
 
-// Scan retrieves the next prediction and stores it within the supplied *types.Prediction, and returns false when
+// Scan retrieves the next prediction and stores it within the supplied *core.Prediction, and returns false when
 // there are no predictions left or there is an error. To differentiate these cases, inspect the Error property.
-func (it *PredictionScanner) Scan(prediction *types.Prediction) bool {
+func (it *PredictionScanner) Scan(prediction *core.Prediction) bool {
 	it.Error = nil
 	if len(it.predictions) == 0 {
 		var err error
 		it.predictions, err = it.query()
 		if err != nil {
 			it.Error = err
-			*prediction = types.Prediction{}
+			*prediction = core.Prediction{}
 			return false
 		}
 	}

--- a/statestorage/state_storage.go
+++ b/statestorage/state_storage.go
@@ -3,24 +3,24 @@ package statestorage
 import (
 	"database/sql"
 
-	"github.com/marianogappa/predictions/types"
+	"github.com/marianogappa/predictions/core"
 )
 
 // StateStorage is the interface to the storage-layer. Currently the only implementation is Postgres.
 // It might be wise to keep this interface, because Postgres might be convenient but it's a terrible choice for
 // this engine's persistence needs.
 type StateStorage interface {
-	GetPredictions(filters types.APIFilters, orderBys []string, limit, offset int) ([]types.Prediction, error)
-	GetAccounts(filters types.APIAccountFilters, orderBys []string, limit, offset int) ([]types.Account, error)
+	GetPredictions(filters core.APIFilters, orderBys []string, limit, offset int) ([]core.Prediction, error)
+	GetAccounts(filters core.APIAccountFilters, orderBys []string, limit, offset int) ([]core.Account, error)
 	// TODO: add interface contract
-	UpsertPredictions([]*types.Prediction) ([]*types.Prediction, error)
-	UpsertAccounts([]*types.Account) ([]*types.Account, error)
-	LogPredictionStateValueChange(types.PredictionStateValueChange) error
+	UpsertPredictions([]*core.Prediction) ([]*core.Prediction, error)
+	UpsertAccounts([]*core.Account) ([]*core.Account, error)
+	LogPredictionStateValueChange(core.PredictionStateValueChange) error
 
-	NonPendingPredictionInteractionExists(types.PredictionInteraction) (bool, error)
-	InsertPredictionInteraction(types.PredictionInteraction) error
-	GetPendingPredictionInteractions() ([]types.PredictionInteraction, error)
-	UpdatePredictionInteractionStatus(types.PredictionInteraction) error
+	NonPendingPredictionInteractionExists(core.PredictionInteraction) (bool, error)
+	InsertPredictionInteraction(core.PredictionInteraction) error
+	GetPendingPredictionInteractions() ([]core.PredictionInteraction, error)
+	UpdatePredictionInteractionStatus(core.PredictionInteraction) error
 
 	PausePrediction(uuid string) error
 	UnpausePrediction(uuid string) error


### PR DESCRIPTION
The types package evolved to have the core prediction evolving logic, so it should be renamed to core.